### PR TITLE
GM-258 Arch. event env. and impl example code

### DIFF
--- a/src/main/java/com/gaaji/townlife/TownLifeApplication.java
+++ b/src/main/java/com/gaaji/townlife/TownLifeApplication.java
@@ -6,12 +6,14 @@ import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 import org.springframework.cloud.netflix.eureka.EnableEurekaClient;
 import org.springframework.cloud.openfeign.EnableFeignClients;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableAsync;
 
 @SpringBootApplication
 @EnableJpaAuditing
 @EnableEurekaClient
 @EnableFeignClients
 @ConfigurationPropertiesScan
+@EnableAsync
 public class TownLifeApplication {
 	public static void main(String[] args) {
 		SpringApplication.run(TownLifeApplication.class, args);

--- a/src/main/java/com/gaaji/townlife/service/adapter/kafka/KafkaProducer.java
+++ b/src/main/java/com/gaaji/townlife/service/adapter/kafka/KafkaProducer.java
@@ -1,0 +1,30 @@
+package com.gaaji.townlife.service.adapter.kafka;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.gaaji.townlife.service.event.BaseEvent;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class KafkaProducer {
+    private final KafkaTemplate<String, String> kafkaTemplate;
+    private final ObjectMapper objectMapper;
+
+    public <T> void produceEvent(BaseEvent<T> baseEvent) {
+        kafkaTemplate.send(baseEvent.getTopic(), writeAsString(baseEvent.getBody()));
+    }
+
+    private <T> String writeAsString(T body) {
+        try {
+            return objectMapper.writeValueAsString(body);
+        } catch (JsonProcessingException e) {
+            log.error("JsonProcessingException from KafkaProducer.writeAsString(MyEvent)" + System.lineSeparator() + "{}", e.getStackTrace());
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/src/main/java/com/gaaji/townlife/service/applicationservice/ApplicationEventPublishingServiceExample.java
+++ b/src/main/java/com/gaaji/townlife/service/applicationservice/ApplicationEventPublishingServiceExample.java
@@ -1,0 +1,20 @@
+package com.gaaji.townlife.service.applicationservice;
+
+import com.gaaji.townlife.service.event.PostEditedEvent;
+import com.gaaji.townlife.service.event.dto.PostEditedEventBody;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class ApplicationEventPublishingServiceExample {
+    private final ApplicationEventPublisher eventPublisher;
+
+    public void test() {
+        log.info("ApplicationEventPublishingServiceExample.test()");
+        eventPublisher.publishEvent(new PostEditedEvent(this, PostEditedEventBody.of("메뉴 추천좀")));
+    }
+}

--- a/src/main/java/com/gaaji/townlife/service/controller/ApplicationEventPublishingControllerExample.java
+++ b/src/main/java/com/gaaji/townlife/service/controller/ApplicationEventPublishingControllerExample.java
@@ -1,0 +1,23 @@
+package com.gaaji.townlife.service.controller;
+
+import com.gaaji.townlife.service.applicationservice.ApplicationEventPublishingServiceExample;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@Slf4j
+public class ApplicationEventPublishingControllerExample {
+    private final ApplicationEventPublishingServiceExample service;
+
+    @GetMapping("/test/publish-event")
+    @ResponseStatus(HttpStatus.OK)
+    public void testPublishEvent() {
+        log.info("/test/publish-event");
+        service.test();
+    }
+}

--- a/src/main/java/com/gaaji/townlife/service/event/ApplicationEventHandler.java
+++ b/src/main/java/com/gaaji/townlife/service/event/ApplicationEventHandler.java
@@ -1,0 +1,30 @@
+package com.gaaji.townlife.service.event;
+
+import com.gaaji.townlife.service.adapter.kafka.KafkaProducer;
+import com.gaaji.townlife.service.event.dto.NotificationEventBody;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+
+@Component
+@Slf4j
+@RequiredArgsConstructor
+/**
+ * ex) 서비스에서 게시글 변경 이벤트를 발생시키면 이 핸들러에서 다음과 같이 처리한다.
+ * 1. kafka 에 같은 이벤트를 produce
+ * 2. kafka 에 noti-server 이벤트를 produce
+ *
+ */
+public class ApplicationEventHandler {
+    private final KafkaProducer kafkaProducer;
+
+    @Async
+    @EventListener
+    public void handlePostEdited(PostEditedEvent event) {
+        // 게시글이 수정되면 그 게시글을 구독중인 사용자에게 알림이 가야 한다.
+        kafkaProducer.produceEvent(event);
+        kafkaProducer.produceEvent(new NotificationEvent(this, NotificationEventBody.of("게시글 변경됐네요~ 확인해봐요", "id1", "id2", "id3")));
+    }
+}

--- a/src/main/java/com/gaaji/townlife/service/event/BaseEvent.java
+++ b/src/main/java/com/gaaji/townlife/service/event/BaseEvent.java
@@ -1,0 +1,16 @@
+package com.gaaji.townlife.service.event;
+
+import lombok.Getter;
+import org.springframework.context.ApplicationEvent;
+
+@Getter
+public abstract class BaseEvent<T> extends ApplicationEvent {
+    protected String topic;
+    protected T body;
+
+    public BaseEvent(Object source, String topic, T body) {
+        super(source);
+        this.topic = topic;
+        this.body = body;
+    }
+}

--- a/src/main/java/com/gaaji/townlife/service/event/NotificationEvent.java
+++ b/src/main/java/com/gaaji/townlife/service/event/NotificationEvent.java
@@ -1,0 +1,9 @@
+package com.gaaji.townlife.service.event;
+
+import com.gaaji.townlife.service.event.dto.NotificationEventBody;
+
+public class NotificationEvent extends BaseEvent<NotificationEventBody> {
+    public NotificationEvent(Object source, NotificationEventBody body) {
+        super(source, "noti-server", body);
+    }
+}

--- a/src/main/java/com/gaaji/townlife/service/event/PostEditedEvent.java
+++ b/src/main/java/com/gaaji/townlife/service/event/PostEditedEvent.java
@@ -1,0 +1,9 @@
+package com.gaaji.townlife.service.event;
+
+import com.gaaji.townlife.service.event.dto.PostEditedEventBody;
+
+public class PostEditedEvent extends BaseEvent<PostEditedEventBody> {
+    public PostEditedEvent(Object source, PostEditedEventBody body) {
+        super(source, "townLife-townLifeUpdated", body);
+    }
+}

--- a/src/main/java/com/gaaji/townlife/service/event/dto/NotificationEventBody.java
+++ b/src/main/java/com/gaaji/townlife/service/event/dto/NotificationEventBody.java
@@ -1,0 +1,18 @@
+package com.gaaji.townlife.service.event.dto;
+
+import lombok.Getter;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+public class NotificationEventBody {
+    private List<String> users = new ArrayList<>();
+    private String message = "";
+
+    public static NotificationEventBody of(String message, String... users) {
+        NotificationEventBody body = new NotificationEventBody();
+        body.users.addAll(List.of(users));
+        return body;
+    }
+}

--- a/src/main/java/com/gaaji/townlife/service/event/dto/PostEditedEventBody.java
+++ b/src/main/java/com/gaaji/townlife/service/event/dto/PostEditedEventBody.java
@@ -1,0 +1,14 @@
+package com.gaaji.townlife.service.event.dto;
+
+import lombok.Getter;
+
+@Getter
+public class PostEditedEventBody {
+    private String title;
+
+    public static PostEditedEventBody of(String title) {
+        PostEditedEventBody postEditedEventBody = new PostEditedEventBody();
+        postEditedEventBody.title = title;
+        return postEditedEventBody;
+    }
+}


### PR DESCRIPTION
# GM-258 Arch. event env. and impl example code
## Description
Application Event와 Kafka를 사용한다.

## PR Type
- [ ] Hotfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor (code, package, etc.)
- [ ] Build (gradle, spring, etc) 
- [ ] Documentation content changes (api docs, etc.)
- [ ] Infra (cloud, security, etc.)
- [ ] Other... Please describe :

## Related Issues
- 

## Issues
서비스단에서 다음과 같이 이벤트를 publish.
```java
@Service
@RequiredArgsConstructor
@Slf4j
public class ApplicationEventPublishingServiceExample {
    private final ApplicationEventPublisher eventPublisher;

    public void test() {
        log.info("ApplicationEventPublishingServiceExample.test()");
        eventPublisher.publishEvent(new PostEditedEvent(this, PostEditedEventBody.of("메뉴 추천좀")));
    }
}
```
이벤트는 다음과 같이 정의한다.
```java
public class PostEditedEvent extends BaseEvent<PostEditedEventBody> {
    public PostEditedEvent(Object source, PostEditedEventBody body) {
        super(source, "townLife-townLifeUpdated", body);
    }
}
```
이벤트 핸들러는 다음과 같이 작성한다.
```java
// service.event.Application.EventHandler.java
    @Async
    @EventListener
    public void handlePostEdited(PostEditedEvent event) {
        // 게시글이 수정되면 그 게시글을 구독중인 사용자에게 알림이 가야 한다.
        kafkaProducer.produceEvent(event);
        kafkaProducer.produceEvent(new NotificationEvent(this, NotificationEventBody.of("게시글 변경됐네요~ 확인해봐요", "id1", "id2", "id3")));
    }
```

## Test
![image](https://user-images.githubusercontent.com/74762475/218956371-880d0a6f-9724-4eb8-8ab1-944a0d9b2023.png)
