### PR TITLE
[GM-270] find service 로직 추가 및 테스트

### DIFF
--- a/src/main/java/com/gaaji/townlife/global/exception/api/AbstractApiException.java
+++ b/src/main/java/com/gaaji/townlife/global/exception/api/AbstractApiException.java
@@ -9,12 +9,20 @@ public class AbstractApiException extends RuntimeException implements ErrorCode{
     protected String errorCode;
     protected String errorName;
     protected String errorMessage;
+    protected Throwable cause;
 
     public AbstractApiException (ErrorCode errorCode) {
-
         httpStatus = errorCode.getHttpStatus();
         this.errorCode = errorCode.getErrorCode();
         errorName = errorCode.getErrorName();
         errorMessage = errorCode.getErrorMessage();
+    }
+
+    public AbstractApiException(ErrorCode errorCode, Throwable cause) {
+        httpStatus = errorCode.getHttpStatus();
+        this.errorCode = errorCode.getErrorCode();
+        errorName = errorCode.getErrorName();
+        errorMessage = errorCode.getErrorMessage();
+        this.cause = cause;
     }
 }

--- a/src/main/java/com/gaaji/townlife/global/exception/api/ApiErrorCode.java
+++ b/src/main/java/com/gaaji/townlife/global/exception/api/ApiErrorCode.java
@@ -7,7 +7,10 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 @Getter
 public enum ApiErrorCode implements ErrorCode {
-    TOWN_LIFE_NOT_FOUND(HttpStatus.NOT_FOUND, "tl-0001", "해당 동네생활을 찾을 수 없습니다.");
+    TOWN_LIFE_NOT_FOUND(HttpStatus.NOT_FOUND, "TL-0001", "해당 동네생활을 찾을 수 없습니다."),
+    TOWN_LIFE_SAVE_ERROR(HttpStatus.BAD_REQUEST, "TL-0002", "동네생활 게시글 등록에 실패하였습니다."),
+    CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND, "TL-0010", "해당 카테고리를 찾을 수 없습니다."),
+    ;
     private final HttpStatus httpStatus;
     private final String errorCode;
     private final String errorMessage;

--- a/src/main/java/com/gaaji/townlife/global/exception/api/ResourceSaveException.java
+++ b/src/main/java/com/gaaji/townlife/global/exception/api/ResourceSaveException.java
@@ -1,0 +1,13 @@
+package com.gaaji.townlife.global.exception.api;
+
+import lombok.Getter;
+
+@Getter
+public class ResourceSaveException extends AbstractApiException {
+    public ResourceSaveException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+    public ResourceSaveException(ErrorCode errorCode, Throwable cause) {
+        super(errorCode, cause);
+    }
+}

--- a/src/main/java/com/gaaji/townlife/service/applicationservice/townlife/TownLifeFindCountService.java
+++ b/src/main/java/com/gaaji/townlife/service/applicationservice/townlife/TownLifeFindCountService.java
@@ -1,9 +1,10 @@
 package com.gaaji.townlife.service.applicationservice.townlife;
 
+import com.gaaji.townlife.service.domain.townlife.TownLife;
 import com.gaaji.townlife.service.domain.townlife.TownLifeCounter;
 
 public interface TownLifeFindCountService {
 
-    TownLifeCounter increaseViewCount(String id);
+    TownLifeCounter increaseViewCount(TownLife townLife);
 
 }

--- a/src/main/java/com/gaaji/townlife/service/applicationservice/townlife/TownLifeFindCountServiceImpl.java
+++ b/src/main/java/com/gaaji/townlife/service/applicationservice/townlife/TownLifeFindCountServiceImpl.java
@@ -2,6 +2,7 @@ package com.gaaji.townlife.service.applicationservice.townlife;
 
 import com.gaaji.townlife.global.exception.api.ApiErrorCode;
 import com.gaaji.townlife.global.exception.api.ResourceNotFoundException;
+import com.gaaji.townlife.service.domain.townlife.TownLife;
 import com.gaaji.townlife.service.domain.townlife.TownLifeCounter;
 import com.gaaji.townlife.service.repository.TownLifeCounterRepository;
 import lombok.RequiredArgsConstructor;
@@ -16,8 +17,8 @@ public class TownLifeFindCountServiceImpl implements TownLifeFindCountService {
 
     @Override
     @Transactional
-    public TownLifeCounter increaseViewCount(String id) {
-        TownLifeCounter townLifeCounter = townLifeCounterRepository.findById(id)
+    public TownLifeCounter increaseViewCount(TownLife townLife) {
+        TownLifeCounter townLifeCounter = townLifeCounterRepository.findByTownLife(townLife)
                 .orElseThrow(() -> new ResourceNotFoundException(ApiErrorCode.TOWN_LIFE_NOT_FOUND));
 
         return townLifeCounter.view();

--- a/src/main/java/com/gaaji/townlife/service/applicationservice/townlife/TownLifeFindEntityService.java
+++ b/src/main/java/com/gaaji/townlife/service/applicationservice/townlife/TownLifeFindEntityService.java
@@ -10,6 +10,10 @@ public interface TownLifeFindEntityService {
 
     List<TownLife> findListByTownId(String townId, int size);
 
-    List<TownLife> findListByTownIdAndIdLessThan(String townId, String lastTownLifeId, int size);
+    List<TownLife> findMoreListByTownIdAndIdLessThan(String townId, String lastTownLifeId, int size);
+
+    List<TownLife> findListByAuthorId(String authorId, int size);
+
+    List<TownLife> findMoreListByAuthorIdAndIdLessThan(String authorId, String lastTownLifeId, int size);
 
 }

--- a/src/main/java/com/gaaji/townlife/service/applicationservice/townlife/TownLifeFindEntityService.java
+++ b/src/main/java/com/gaaji/townlife/service/applicationservice/townlife/TownLifeFindEntityService.java
@@ -2,8 +2,14 @@ package com.gaaji.townlife.service.applicationservice.townlife;
 
 import com.gaaji.townlife.service.domain.townlife.TownLife;
 
+import java.util.List;
+
 public interface TownLifeFindEntityService {
 
     TownLife findById(String id);
+
+    List<TownLife> findListByTownId(String townId, int size);
+
+    List<TownLife> findListByTownIdAndIdLessThan(String townId, String lastTownLifeId, int size);
 
 }

--- a/src/main/java/com/gaaji/townlife/service/applicationservice/townlife/TownLifeFindEntityServiceImpl.java
+++ b/src/main/java/com/gaaji/townlife/service/applicationservice/townlife/TownLifeFindEntityServiceImpl.java
@@ -5,8 +5,13 @@ import com.gaaji.townlife.global.exception.api.ResourceNotFoundException;
 import com.gaaji.townlife.service.domain.townlife.TownLife;
 import com.gaaji.townlife.service.repository.TownLifeRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
+
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class TownLifeFindEntityServiceImpl implements TownLifeFindEntityService {
@@ -15,7 +20,30 @@ public class TownLifeFindEntityServiceImpl implements TownLifeFindEntityService 
 
     @Override
     public TownLife findById(String id) {
+
         return townLifeRepository.findById(id)
                 .orElseThrow(() -> new ResourceNotFoundException(ApiErrorCode.TOWN_LIFE_NOT_FOUND));
+    }
+
+    @Override
+    public List<TownLife> findListByTownId(String townId, int size) {
+
+        PageRequest page = PageRequest.ofSize(size);
+        List<TownLife> townLives = townLifeRepository.findByTownId(townId, page);
+
+        if(townLives == null || townLives.size() == 0) throw new ResourceNotFoundException(ApiErrorCode.TOWN_LIFE_NOT_FOUND);
+
+        return townLives;
+    }
+
+    @Override
+    public List<TownLife> findListByTownIdAndIdLessThan(String townId, String lastTownLifeId, int size) {
+
+        PageRequest page = PageRequest.ofSize(size);
+        List<TownLife> townLives = townLifeRepository.findByTownIdAndIdLessThan(townId, lastTownLifeId, page);
+
+        if(townLives == null || townLives.size() == 0) throw new ResourceNotFoundException(ApiErrorCode.TOWN_LIFE_NOT_FOUND);
+
+        return townLives;
     }
 }

--- a/src/main/java/com/gaaji/townlife/service/applicationservice/townlife/TownLifeFindEntityServiceImpl.java
+++ b/src/main/java/com/gaaji/townlife/service/applicationservice/townlife/TownLifeFindEntityServiceImpl.java
@@ -31,19 +31,47 @@ public class TownLifeFindEntityServiceImpl implements TownLifeFindEntityService 
         PageRequest page = PageRequest.ofSize(size);
         List<TownLife> townLives = townLifeRepository.findByTownId(townId, page);
 
-        if(townLives == null || townLives.size() == 0) throw new ResourceNotFoundException(ApiErrorCode.TOWN_LIFE_NOT_FOUND);
+        validateExistTownLives(townLives);
 
         return townLives;
     }
 
     @Override
-    public List<TownLife> findListByTownIdAndIdLessThan(String townId, String lastTownLifeId, int size) {
+    public List<TownLife> findMoreListByTownIdAndIdLessThan(String townId, String lastTownLifeId, int size) {
 
         PageRequest page = PageRequest.ofSize(size);
         List<TownLife> townLives = townLifeRepository.findByTownIdAndIdLessThan(townId, lastTownLifeId, page);
 
-        if(townLives == null || townLives.size() == 0) throw new ResourceNotFoundException(ApiErrorCode.TOWN_LIFE_NOT_FOUND);
+        validateExistTownLives(townLives);
 
         return townLives;
+    }
+
+    @Override
+    public List<TownLife> findListByAuthorId(String authorId, int size) {
+
+        PageRequest page = PageRequest.ofSize(size);
+        List<TownLife> townLives = townLifeRepository.findByAuthorId(authorId, page);
+
+        validateExistTownLives(townLives);
+
+        return townLives;
+    }
+
+    @Override
+    public List<TownLife> findMoreListByAuthorIdAndIdLessThan(String authorId, String lastTownLifeId, int size) {
+
+        PageRequest page = PageRequest.ofSize(size);
+        List<TownLife> townLives = townLifeRepository.findByAuthorIdAndIdLessThan(authorId, lastTownLifeId, page);
+
+        validateExistTownLives(townLives);
+
+        return townLives;
+    }
+
+    private void validateExistTownLives(List<TownLife> townLives) {
+        if(townLives == null || townLives.size() == 0) {
+            throw new ResourceNotFoundException(ApiErrorCode.TOWN_LIFE_NOT_FOUND);
+        }
     }
 }

--- a/src/main/java/com/gaaji/townlife/service/applicationservice/townlife/TownLifeFindService.java
+++ b/src/main/java/com/gaaji/townlife/service/applicationservice/townlife/TownLifeFindService.java
@@ -10,6 +10,6 @@ public interface TownLifeFindService {
     TownLifeDetailDto findById(String id);
     TownLifeDetailDto visit(String id);
     List<TownLifeListDto> findListByTownId(String townId, String lastTownLifeId, int size);
-    List<TownLifeListDto> findListByUserId(String userId);
+    List<TownLifeListDto> findListByUserId(String userId, String lastTownLifeId, int size);
 
 }

--- a/src/main/java/com/gaaji/townlife/service/applicationservice/townlife/TownLifeFindServiceImpl.java
+++ b/src/main/java/com/gaaji/townlife/service/applicationservice/townlife/TownLifeFindServiceImpl.java
@@ -1,13 +1,18 @@
 package com.gaaji.townlife.service.applicationservice.townlife;
 
+import com.gaaji.townlife.global.exception.api.ApiErrorCode;
+import com.gaaji.townlife.global.exception.api.ResourceNotFoundException;
 import com.gaaji.townlife.service.controller.townlife.dto.TownLifeDetailDto;
 import com.gaaji.townlife.service.controller.townlife.dto.TownLifeListDto;
 import com.gaaji.townlife.service.domain.townlife.TownLife;
 import com.gaaji.townlife.service.domain.townlife.TownLifeCounter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -24,16 +29,31 @@ public class TownLifeFindServiceImpl implements TownLifeFindService {
     }
 
     @Override
+    @Transactional
     public TownLifeDetailDto visit(String id) {
         TownLife townLife = entityService.findById(id);
-        TownLifeCounter townLifeCounter = countService.increaseViewCount(id);
+        TownLifeCounter townLifeCounter = countService.increaseViewCount(townLife);
 
         return TownLifeDetailDto.of(townLife, townLifeCounter);
     }
 
     @Override
+    @Transactional
     public List<TownLifeListDto> findListByTownId(String townId, String lastTownLifeId, int size) {
-        return null;
+        List<TownLife> townLives;
+
+        if(Objects.equals("-1", lastTownLifeId)) {
+            townLives = entityService.findListByTownId(townId, size);
+        } else {
+            townLives = entityService.findListByTownIdAndIdLessThan(townId, lastTownLifeId, size);
+        }
+        if(townLives == null || townLives.size() == 0) {
+            throw new ResourceNotFoundException(ApiErrorCode.TOWN_LIFE_NOT_FOUND);
+        }
+
+        return townLives.stream()
+                .map(townLife -> TownLifeListDto.of(townLife, townLife.getTownLifeCounter()))
+                .collect(Collectors.toList());
     }
 
     @Override

--- a/src/main/java/com/gaaji/townlife/service/applicationservice/townlife/TownLifeFindServiceImpl.java
+++ b/src/main/java/com/gaaji/townlife/service/applicationservice/townlife/TownLifeFindServiceImpl.java
@@ -1,7 +1,5 @@
 package com.gaaji.townlife.service.applicationservice.townlife;
 
-import com.gaaji.townlife.global.exception.api.ApiErrorCode;
-import com.gaaji.townlife.global.exception.api.ResourceNotFoundException;
 import com.gaaji.townlife.service.controller.townlife.dto.TownLifeDetailDto;
 import com.gaaji.townlife.service.controller.townlife.dto.TownLifeListDto;
 import com.gaaji.townlife.service.domain.townlife.TownLife;
@@ -45,19 +43,29 @@ public class TownLifeFindServiceImpl implements TownLifeFindService {
         if(Objects.equals("-1", lastTownLifeId)) {
             townLives = entityService.findListByTownId(townId, size);
         } else {
-            townLives = entityService.findListByTownIdAndIdLessThan(townId, lastTownLifeId, size);
-        }
-        if(townLives == null || townLives.size() == 0) {
-            throw new ResourceNotFoundException(ApiErrorCode.TOWN_LIFE_NOT_FOUND);
+            townLives = entityService.findMoreListByTownIdAndIdLessThan(townId, lastTownLifeId, size);
         }
 
-        return townLives.stream()
-                .map(townLife -> TownLifeListDto.of(townLife, townLife.getTownLifeCounter()))
-                .collect(Collectors.toList());
+        return convertDtoListFromEntityList(townLives);
     }
 
     @Override
-    public List<TownLifeListDto> findListByUserId(String userId) {
-        return null;
+    @Transactional
+    public List<TownLifeListDto> findListByUserId(String userId, String lastTownLifeId, int size) {
+        List<TownLife> townLives;
+
+        if(Objects.equals("-1", lastTownLifeId)) {
+            townLives = entityService.findListByAuthorId(userId, size);
+        } else {
+            townLives = entityService.findMoreListByAuthorIdAndIdLessThan(userId, lastTownLifeId, size);
+        }
+
+        return convertDtoListFromEntityList(townLives);
+    }
+
+    private List<TownLifeListDto> convertDtoListFromEntityList(List<TownLife> townLives) {
+        return townLives.stream()
+                .map(townLife -> TownLifeListDto.of(townLife, townLife.getTownLifeCounter()))
+                .collect(Collectors.toList());
     }
 }

--- a/src/main/java/com/gaaji/townlife/service/applicationservice/townlife/TownLifeSaveServiceImpl.java
+++ b/src/main/java/com/gaaji/townlife/service/applicationservice/townlife/TownLifeSaveServiceImpl.java
@@ -1,10 +1,14 @@
 package com.gaaji.townlife.service.applicationservice.townlife;
 
+import com.gaaji.townlife.global.exception.api.ApiErrorCode;
+import com.gaaji.townlife.global.exception.api.ResourceNotFoundException;
+import com.gaaji.townlife.global.exception.api.ResourceSaveException;
 import com.gaaji.townlife.service.controller.townlife.dto.TownLifeDetailDto;
 import com.gaaji.townlife.service.controller.townlife.dto.TownLifeSaveRequestDto;
 import com.gaaji.townlife.service.domain.category.Category;
 import com.gaaji.townlife.service.domain.townlife.*;
 import com.gaaji.townlife.service.repository.CategoryRepository;
+import com.gaaji.townlife.service.repository.TownLifeCounterRepository;
 import com.gaaji.townlife.service.repository.TownLifeRepository;
 import com.gaaji.townlife.service.repository.TownLifeSubscriptionRepository;
 import lombok.RequiredArgsConstructor;
@@ -15,46 +19,57 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class TownLifeSaveServiceImpl implements TownLifeSaveService {
 
-    private final TownLifeRepository townLifeRepository;
-    private final TownLifeSubscriptionRepository townLifeSubscriptionRepository;
     private final CategoryRepository categoryRepository;
+    private final TownLifeRepository townLifeRepository;
+    private final TownLifeCounterRepository townLifeCounterRepository;
+    private final TownLifeSubscriptionRepository townLifeSubscriptionRepository;
 
     @Override
     @Transactional
     public TownLifeDetailDto save(TownLifeType type, TownLifeSaveRequestDto dto) {
-        Category category = categoryRepository.findById(dto.getCategoryId()).orElseThrow();
+        Category category = categoryRepository.findById(dto.getCategoryId())
+                .orElseThrow(() -> new ResourceNotFoundException(ApiErrorCode.CATEGORY_NOT_FOUND));
 
-//        if(dto.getAttachedImageRequestFiles() != null) {
-//            // save s3
-//            // return s3 url
-//            // set attached image src
-//        }
-
-        TownLifeDetailDto townLifeDetailDto = null;
+        TownLifeDetailDto responseDto = null;
         switch (type) {
             case POST:
-                PostTownLife postTownLife = townLifeRepository.save(PostTownLife.create(dto));
-                postTownLife.associateCategory(category);
-
-                saveSubscription(postTownLife, dto.getAuthorId());
-                townLifeDetailDto = TownLifeDetailDto.of(postTownLife);
+                PostTownLife postTownLife = saveTownLife(PostTownLife.class, dto, category);
+                responseDto = TownLifeDetailDto.of(postTownLife);
                 break;
             case QUESTION:
-                QuestionTownLife questionTownLife = townLifeRepository.save(QuestionTownLife.create(dto));
-                questionTownLife.associateCategory(category);
-
-                saveSubscription(questionTownLife, dto.getAuthorId());
-                townLifeDetailDto = TownLifeDetailDto.of(questionTownLife);
+                QuestionTownLife questionTownLife = saveTownLife(QuestionTownLife.class, dto, category);
+                responseDto = TownLifeDetailDto.of(questionTownLife);
                 break;
         }
-        assert townLifeDetailDto != null;
+        if(responseDto == null) throw new ResourceSaveException(ApiErrorCode.TOWN_LIFE_SAVE_ERROR);
 
-        return townLifeDetailDto;
+        return responseDto;
+    }
+
+    private <T extends TownLife> T saveTownLife(Class<T> townLifeClass, TownLifeSaveRequestDto dto, Category category) {
+        try {
+            T townLife = townLifeRepository.save(
+                    townLifeClass.getConstructor(String.class, String.class, TownLifeContent.class)
+                            .newInstance(dto.getAuthorId(), dto.getTownId(), TownLifeContent.of(dto.getTitle(), dto.getText(), dto.getLocation())));
+            townLife.associateCategory(category);
+            saveSubscription(townLife, dto.getAuthorId());
+            saveCounter(townLife);
+            return townLife;
+
+        } catch (Exception e) {
+            throw new ResourceSaveException(ApiErrorCode.TOWN_LIFE_SAVE_ERROR, e);
+        }
     }
 
     private <T extends TownLife> void saveSubscription(T townLife, String authorId) {
         TownLifeSubscription subscription = townLifeSubscriptionRepository.save(TownLifeSubscription.of(authorId));
         subscription.associateTownLife(townLife);
+    }
+
+    private <T extends TownLife> void saveCounter(T townLife) {
+        TownLifeCounter counter = TownLifeCounter.create();
+        townLifeCounterRepository.save(counter);
+        townLife.associateCounter(counter);
     }
 
 }

--- a/src/main/java/com/gaaji/townlife/service/controller/townlife/dto/TownLifeListDto.java
+++ b/src/main/java/com/gaaji/townlife/service/controller/townlife/dto/TownLifeListDto.java
@@ -1,4 +1,39 @@
 package com.gaaji.townlife.service.controller.townlife.dto;
 
+import com.gaaji.townlife.service.domain.townlife.TownLife;
+import com.gaaji.townlife.service.domain.townlife.TownLifeCounter;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Getter @ToString
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
 public class TownLifeListDto {
+
+    private String id;
+    private String categoryId;
+    private String categoryName;
+    private String townId;
+    private String title;
+    private LocalDateTime createdAt;
+    private int commentCount;
+    private int reactionCount;
+    private String thumbnailSrc;
+
+    public static TownLifeListDto of(TownLife entity, TownLifeCounter counter) {
+        return TownLifeListDto.builder()
+                .id(entity.getId())
+                .categoryId(entity.getCategory().getId())
+                .categoryName(entity.getCategory().getName())
+                .townId(entity.getTownId())
+                .title(entity.getContent().getTitle())
+                .createdAt(entity.getCreatedAt())
+                .commentCount(counter.getCommentCount().getValue())
+                .reactionCount(counter.getReactionCount().getValue())
+                .thumbnailSrc(entity.getThumbnailSrc())
+                .build();
+    }
+
 }

--- a/src/main/java/com/gaaji/townlife/service/domain/townlife/PostTownLife.java
+++ b/src/main/java/com/gaaji/townlife/service/domain/townlife/PostTownLife.java
@@ -22,7 +22,7 @@ public class PostTownLife extends TownLife {
     @OneToMany(mappedBy = "postTownLife")
     private List<PostReaction> reactions = new ArrayList<>();
 
-    private PostTownLife(String authorId, String townId, TownLifeContent content) {
+    public PostTownLife(String authorId, String townId, TownLifeContent content) {
         super(authorId, townId, content);
     }
 

--- a/src/main/java/com/gaaji/townlife/service/domain/townlife/QuestionTownLife.java
+++ b/src/main/java/com/gaaji/townlife/service/domain/townlife/QuestionTownLife.java
@@ -23,7 +23,7 @@ public class QuestionTownLife extends TownLife {
     @OneToMany(mappedBy = "questionTownLife")
     private List<QuestionReaction> reactions = new ArrayList<>();
 
-    private QuestionTownLife(String authorId, String townId, TownLifeContent content) {
+    public QuestionTownLife(String authorId, String townId, TownLifeContent content) {
         super(authorId, townId, content);
     }
 

--- a/src/main/java/com/gaaji/townlife/service/domain/townlife/TownLife.java
+++ b/src/main/java/com/gaaji/townlife/service/domain/townlife/TownLife.java
@@ -21,7 +21,7 @@ import java.util.List;
 @Inheritance(strategy = InheritanceType.JOINED)
 @DiscriminatorColumn
 @Table(indexes = {
-        @Index(name = "idx__town_life__author_id", columnList = "authorId"),
+        @Index(name = "idx__town_life__author_id__id_desc", columnList = "authorId, id DESC"),
         @Index(name = "idx__town_life__town_id__id_desc", columnList = "townId, id DESC"),
 })
 public abstract class TownLife extends BaseEntity {

--- a/src/main/java/com/gaaji/townlife/service/domain/townlife/TownLife.java
+++ b/src/main/java/com/gaaji/townlife/service/domain/townlife/TownLife.java
@@ -22,7 +22,7 @@ import java.util.List;
 @DiscriminatorColumn
 @Table(indexes = {
         @Index(name = "idx__town_life__author_id", columnList = "authorId"),
-        @Index(name = "idx__town_life__town_id", columnList = "townId"),
+        @Index(name = "idx__town_life__town_id__id_desc", columnList = "townId, id DESC"),
 })
 public abstract class TownLife extends BaseEntity {
 
@@ -68,6 +68,11 @@ public abstract class TownLife extends BaseEntity {
     public void associateCounter(TownLifeCounter townLifeCounter) {
         this.townLifeCounter = townLifeCounter;
         this.townLifeCounter.associateTownLife(this);
+    }
+
+    public String getThumbnailSrc() {
+        if(this.attachedImages.size() == 0) return null;
+        return this.attachedImages.get(0).getSrc();
     }
 
 }

--- a/src/main/java/com/gaaji/townlife/service/repository/TownLifeCounterRepository.java
+++ b/src/main/java/com/gaaji/townlife/service/repository/TownLifeCounterRepository.java
@@ -1,7 +1,13 @@
 package com.gaaji.townlife.service.repository;
 
+import com.gaaji.townlife.service.domain.townlife.TownLife;
 import com.gaaji.townlife.service.domain.townlife.TownLifeCounter;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface TownLifeCounterRepository extends JpaRepository<TownLifeCounter, String> {
+
+    Optional<TownLifeCounter> findByTownLife(TownLife townLife);
+
 }

--- a/src/main/java/com/gaaji/townlife/service/repository/TownLifeRepository.java
+++ b/src/main/java/com/gaaji/townlife/service/repository/TownLifeRepository.java
@@ -1,7 +1,15 @@
 package com.gaaji.townlife.service.repository;
 
 import com.gaaji.townlife.service.domain.townlife.TownLife;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface TownLifeRepository extends JpaRepository<TownLife, String> {
+
+
+    List<TownLife> findByTownId(String townId, Pageable pageable);
+    List<TownLife> findByTownIdAndIdLessThan(String townId, String id, Pageable pageable);
+
 }

--- a/src/main/java/com/gaaji/townlife/service/repository/TownLifeRepository.java
+++ b/src/main/java/com/gaaji/townlife/service/repository/TownLifeRepository.java
@@ -10,6 +10,11 @@ public interface TownLifeRepository extends JpaRepository<TownLife, String> {
 
 
     List<TownLife> findByTownId(String townId, Pageable pageable);
+
     List<TownLife> findByTownIdAndIdLessThan(String townId, String id, Pageable pageable);
+
+    List<TownLife> findByAuthorId(String authorId, Pageable pageable);
+
+    List<TownLife> findByAuthorIdAndIdLessThan(String authorId, String id, Pageable pageable);
 
 }

--- a/src/test/java/com/gaaji/townlife/service/applicationservice/townlife/TownLifeFindServiceImplTest.java
+++ b/src/test/java/com/gaaji/townlife/service/applicationservice/townlife/TownLifeFindServiceImplTest.java
@@ -1,24 +1,105 @@
 package com.gaaji.townlife.service.applicationservice.townlife;
 
+import com.gaaji.townlife.service.controller.townlife.dto.TownLifeDetailDto;
+import com.gaaji.townlife.service.controller.townlife.dto.TownLifeListDto;
+import com.gaaji.townlife.service.controller.townlife.dto.TownLifeSaveRequestDto;
+import com.gaaji.townlife.service.domain.category.Category;
+import com.gaaji.townlife.service.domain.townlife.TownLifeType;
+import com.gaaji.townlife.service.repository.CategoryRepository;
 import com.gaaji.townlife.service.repository.TownLifeCounterRepository;
 import com.gaaji.townlife.service.repository.TownLifeRepository;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
 
-@ExtendWith(MockitoExtension.class)
+import java.util.List;
+
+@SpringBootTest
 class TownLifeFindServiceImplTest {
 
-    @Mock private TownLifeRepository townLifeRepository;
-    @Mock private TownLifeCounterRepository townLifeCounterRepository;
-    @Mock private TownLifeFindEntityServiceImpl townLifeFindEntityService;
-    @Mock private TownLifeFindCountServiceImpl townLifeFindCountService;
-    @InjectMocks private TownLifeFindServiceImpl townLifeFindService;
+    @Autowired private CategoryRepository categoryRepository;
+    @Autowired private TownLifeRepository townLifeRepository;
+    @Autowired private TownLifeCounterRepository townLifeCounterRepository;
+    @Autowired private TownLifeFindEntityServiceImpl townLifeFindEntityService;
+    @Autowired private TownLifeFindCountServiceImpl townLifeFindCountService;
+    @Autowired private TownLifeSaveServiceImpl townLifeSaveService;
+    @Autowired private TownLifeFindServiceImpl townLifeFindService;
 
-    void create_town_life() {
+    private String townLifeId;
+    private Category category;
 
+    void init_category() {
+        category = categoryRepository.save(Category.create("테스트_카테고리", true, "테스트_카테고리입니다."));
     }
 
+    void init_post_town_life() {
+        init_category();
+
+        TownLifeSaveRequestDto dto = TownLifeSaveRequestDto.builder()
+                .categoryId(category.getId()).authorId("1").townId("1").title("테스트 게시글").text("테스트 게시글 내용입니다.").location("테스트 장소").build();
+        townLifeId = townLifeSaveService.save(TownLifeType.POST, dto).getId();
+    }
+
+    private static String townId = "1";
+
+    void init_post_town_lives() {
+        init_category();
+        int n = 100;
+
+        for(int i=1; i<=n; i++) {
+            TownLifeSaveRequestDto dto = TownLifeSaveRequestDto.builder()
+                    .categoryId(category.getId()).authorId(String.valueOf(i)).townId(townId)
+                    .title("테스트 게시글").text("테스트 게시글 내용입니다.").location("테스트 장소").build();
+
+            TownLifeDetailDto save = townLifeSaveService.save(TownLifeType.POST, dto);
+            if(i==n) System.out.println(save);
+        }
+    }
+
+    @Test
+    void view_post_town_life() {
+        init_post_town_life();
+
+        TownLifeDetailDto dto = townLifeFindService.visit(townLifeId);
+        Assertions.assertNotNull(dto);
+        Assertions.assertEquals(townLifeId, dto.getId());
+        Assertions.assertEquals(1, dto.getViewCount());
+    }
+
+    @Test
+    void one_thousand_visit_post_town_life() {
+        init_post_town_life();
+
+        TownLifeDetailDto dto = null;
+        for(int i=0; i<1000; i++) {
+            dto = townLifeFindService.visit(townLifeId);
+        }
+        Assertions.assertNotNull(dto);
+        Assertions.assertEquals(townLifeId, dto.getId());
+        Assertions.assertEquals(1000, dto.getViewCount());
+    }
+
+    @Test
+    void find_list_by_town_id() {
+        String defaultLastTownLifeId = "-1";
+        int size = 10;
+
+        init_post_town_lives();
+
+        List<TownLifeListDto> firstView = townLifeFindService.findListByTownId(townId, defaultLastTownLifeId, size);
+        Assertions.assertNotNull(firstView);
+        Assertions.assertNotEquals(0, firstView.size());
+        Assertions.assertEquals(size, firstView.size());
+
+        TownLifeListDto lastTownLifeOfFirstView = firstView.get(firstView.size() - 1);
+        List<TownLifeListDto> secondView = townLifeFindService.findListByTownId(townId, lastTownLifeOfFirstView.getId(), size);
+        Assertions.assertNotNull(secondView);
+        Assertions.assertNotEquals(0, secondView.size());
+        Assertions.assertEquals(size, firstView.size());
+
+        TownLifeListDto lastTownLifeOfSecondView = secondView.get(secondView.size() - 1);
+        Assertions.assertTrue(lastTownLifeOfFirstView.getCreatedAt().isAfter(lastTownLifeOfSecondView.getCreatedAt()));
+    }
 
 }

--- a/src/test/java/com/gaaji/townlife/service/applicationservice/townlife/TownLifeFindServiceImplTest.java
+++ b/src/test/java/com/gaaji/townlife/service/applicationservice/townlife/TownLifeFindServiceImplTest.java
@@ -8,8 +8,7 @@ import com.gaaji.townlife.service.domain.townlife.TownLifeType;
 import com.gaaji.townlife.service.repository.CategoryRepository;
 import com.gaaji.townlife.service.repository.TownLifeCounterRepository;
 import com.gaaji.townlife.service.repository.TownLifeRepository;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
@@ -26,80 +25,150 @@ class TownLifeFindServiceImplTest {
     @Autowired private TownLifeSaveServiceImpl townLifeSaveService;
     @Autowired private TownLifeFindServiceImpl townLifeFindService;
 
-    private String townLifeId;
     private Category category;
 
     void init_category() {
         category = categoryRepository.save(Category.create("테스트_카테고리", true, "테스트_카테고리입니다."));
     }
 
-    void init_post_town_life() {
-        init_category();
+    @Nested
+    @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+    @DisplayName("동네생활 조회 및 조회수 테스트")
+    class Test_For_Find_Specific_One_Town_Life {
 
-        TownLifeSaveRequestDto dto = TownLifeSaveRequestDto.builder()
-                .categoryId(category.getId()).authorId("1").townId("1").title("테스트 게시글").text("테스트 게시글 내용입니다.").location("테스트 장소").build();
-        townLifeId = townLifeSaveService.save(TownLifeType.POST, dto).getId();
-    }
+        private final String authorId = "user01";
+        private final String townId = "town01";
+        private final String title = "테스트 게시글";
+        private final String text = "테스트 게시글 내용입니다.";
+        private final String location = "서울특별시 테스트구 테스트동";
+        private String townLifeId;
 
-    private static String townId = "1";
+        void init_post_town_life_for_visit() {
+            init_category();
 
-    void init_post_town_lives() {
-        init_category();
-        int n = 100;
-
-        for(int i=1; i<=n; i++) {
             TownLifeSaveRequestDto dto = TownLifeSaveRequestDto.builder()
-                    .categoryId(category.getId()).authorId(String.valueOf(i)).townId(townId)
-                    .title("테스트 게시글").text("테스트 게시글 내용입니다.").location("테스트 장소").build();
+                    .categoryId(category.getId()).authorId(authorId).townId(townId)
+                    .title(title).text(text).location(location).build();
+            townLifeId = townLifeSaveService.save(TownLifeType.POST, dto).getId();
+        }
 
-            TownLifeDetailDto save = townLifeSaveService.save(TownLifeType.POST, dto);
-            if(i==n) System.out.println(save);
+        @Test
+        @Order(100)
+        @DisplayName("동네생활 1회 조회")
+        void view_post_town_life() {
+            init_post_town_life_for_visit();
+
+            TownLifeDetailDto dto = townLifeFindService.visit(townLifeId);
+            Assertions.assertNotNull(dto);
+            Assertions.assertEquals(townLifeId, dto.getId());
+            Assertions.assertEquals(1, dto.getViewCount());
+        }
+
+        @Test
+        @Order(200)
+        @DisplayName("동네생활 1000회 조회")
+        void one_thousand_visit_post_town_life() {
+            init_post_town_life_for_visit();
+
+            TownLifeDetailDto dto = null;
+            for(int i=0; i<1000; i++) {
+                dto = townLifeFindService.visit(townLifeId);
+            }
+            Assertions.assertNotNull(dto);
+            Assertions.assertEquals(townLifeId, dto.getId());
+            Assertions.assertEquals(1000, dto.getViewCount());
         }
     }
 
-    @Test
-    void view_post_town_life() {
-        init_post_town_life();
+    @Nested
+    @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+    @DisplayName("동네생활 메인 페이지 리스트 조회 테스트")
+    class Test_For_Find_Town_Life_List_By_Town_Id {
+        private final String townId = "town01";
+        void init_post_town_lives_for_find_by_town_id() {
+            init_category();
+            int n = 100;
 
-        TownLifeDetailDto dto = townLifeFindService.visit(townLifeId);
-        Assertions.assertNotNull(dto);
-        Assertions.assertEquals(townLifeId, dto.getId());
-        Assertions.assertEquals(1, dto.getViewCount());
-    }
-
-    @Test
-    void one_thousand_visit_post_town_life() {
-        init_post_town_life();
-
-        TownLifeDetailDto dto = null;
-        for(int i=0; i<1000; i++) {
-            dto = townLifeFindService.visit(townLifeId);
+            for(int i=1; i<=n; i++) {
+                TownLifeSaveRequestDto dto = TownLifeSaveRequestDto.builder()
+                        .categoryId(category.getId()).authorId(String.valueOf(i)).townId(townId)
+                        .title("테스트 게시글").text("테스트 게시글 내용입니다.").location("테스트 장소").build();
+                townLifeSaveService.save(TownLifeType.POST, dto);
+            }
         }
-        Assertions.assertNotNull(dto);
-        Assertions.assertEquals(townLifeId, dto.getId());
-        Assertions.assertEquals(1000, dto.getViewCount());
+
+        private final String defaultLastTownLifeId = "-1";
+        private final int size = 10;
+
+        @Test
+        @Order(100)
+        @DisplayName("메인 페이지 리스트 조회 - 메인, 더보기")
+        void find_list_by_town_id() {
+            init_post_town_lives_for_find_by_town_id();
+
+            List<TownLifeListDto> firstView = townLifeFindService.findListByTownId(townId, defaultLastTownLifeId, size);
+            Assertions.assertNotNull(firstView);
+            Assertions.assertNotEquals(0, firstView.size());
+            Assertions.assertEquals(size, firstView.size());
+
+            TownLifeListDto lastTownLifeOfFirstView = firstView.get(firstView.size() - 1);
+            List<TownLifeListDto> moreView = townLifeFindService.findListByTownId(townId, lastTownLifeOfFirstView.getId(), size);
+            Assertions.assertNotNull(moreView);
+            Assertions.assertNotEquals(0, moreView.size());
+            Assertions.assertEquals(size, firstView.size());
+
+            TownLifeListDto lastTownLifeOfSecondView = moreView.get(moreView.size() - 1);
+            Assertions.assertTrue(lastTownLifeOfFirstView.getCreatedAt().isAfter(lastTownLifeOfSecondView.getCreatedAt()));
+        }
+
     }
 
-    @Test
-    void find_list_by_town_id() {
-        String defaultLastTownLifeId = "-1";
-        int size = 10;
+    @Nested
+    @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+    @DisplayName("동네생활 내가 작성한 게시글 리스트 조회 테스트")
+    class Test_For_Find_Town_Life_List_By_User_Id {
+        private final String townId = "town01";
+        private final String tester = "tester";
+        private int testerId = 1;
+        void init_post_town_lives_for_find_by_user_id() {
+            init_category();
+            int n = 100;
 
-        init_post_town_lives();
+            for(int i=1; i<=n; i++) {
+                String authorId  = tester + testerId;
+                TownLifeSaveRequestDto dto = TownLifeSaveRequestDto.builder()
+                        .categoryId(category.getId()).authorId(authorId).townId(townId)
+                        .title("테스트 게시글 "+ i).text("테스트 게시글 내용입니다.").location("테스트 장소").build();
+                testerId = (testerId+1) % 4;
+                townLifeSaveService.save(TownLifeType.POST, dto);
+            }
+        }
 
-        List<TownLifeListDto> firstView = townLifeFindService.findListByTownId(townId, defaultLastTownLifeId, size);
-        Assertions.assertNotNull(firstView);
-        Assertions.assertNotEquals(0, firstView.size());
-        Assertions.assertEquals(size, firstView.size());
+        private final String defaultLastTownLifeId = "-1";
+        private final String userId = "tester2";
+        private final int size = 10;
 
-        TownLifeListDto lastTownLifeOfFirstView = firstView.get(firstView.size() - 1);
-        List<TownLifeListDto> secondView = townLifeFindService.findListByTownId(townId, lastTownLifeOfFirstView.getId(), size);
-        Assertions.assertNotNull(secondView);
-        Assertions.assertNotEquals(0, secondView.size());
-        Assertions.assertEquals(size, firstView.size());
+        @Test
+        @Order(100)
+        @DisplayName("내 게시글 리스트 조회 - 메인, 더보기")
+        void find_list_by_user_id() {
+            init_post_town_lives_for_find_by_user_id();
 
-        TownLifeListDto lastTownLifeOfSecondView = secondView.get(secondView.size() - 1);
-        Assertions.assertTrue(lastTownLifeOfFirstView.getCreatedAt().isAfter(lastTownLifeOfSecondView.getCreatedAt()));
+            List<TownLifeListDto> firstView = townLifeFindService.findListByUserId(userId, defaultLastTownLifeId, size);
+            Assertions.assertNotNull(firstView);
+            Assertions.assertNotEquals(0, firstView.size());
+            Assertions.assertEquals(size, firstView.size());
+
+            TownLifeListDto lastTownLifeOfFirstView = firstView.get(firstView.size() - 1);
+            List<TownLifeListDto> moreView = townLifeFindService.findListByUserId(userId, lastTownLifeOfFirstView.getId(), size);
+            Assertions.assertNotNull(moreView);
+            Assertions.assertNotEquals(0, moreView.size());
+            Assertions.assertEquals(size, firstView.size());
+
+            TownLifeListDto lastTownLifeOfSecondView = moreView.get(moreView.size() - 1);
+            Assertions.assertTrue(lastTownLifeOfFirstView.getCreatedAt().isAfter(lastTownLifeOfSecondView.getCreatedAt()));
+        }
+
     }
 
 }


### PR DESCRIPTION
# [GM-270] find service 로직 추가 및 테스트
## Description
> TownLife의 조회 서비스 레이어에 대한 로직을 추가하였다.

## PR Type
- [ ] Hotfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor (code, package, etc.)
- [ ] Build (gradle, spring, etc) 
- [ ] Documentation content changes (api docs, etc.)
- [ ] Infra (cloud, security, etc.)
- [ ] Other... Please describe :

## Related Issues
-  [GM-262] townlife service 구현

## Issues
### 게시글 find와 방문 분리
find는 단순히 게시글의 정보를 가져오는 것에 대한 역할만 수행하고, 방문 로직은 게시글 정보 및 조회수를 +1 증가하여 응답하는 역할을 수행한다.

아예 FindService를 세분화하였다.  FindService의 구조는 다음과 같다.

![image](https://user-images.githubusercontent.com/42243302/219303321-3cac5a51-c710-4897-b0aa-163c2b2c7cd3.png)


```java
// class TownLifeFindServiceImpl
    @Override
    @Transactional
    public TownLifeDetailDto visit(String id) {
        TownLife townLife = entityService.findById(id);
        TownLifeCounter townLifeCounter = countService.increaseViewCount(townLife);
        return TownLifeDetailDto.of(townLife, townLifeCounter);
    }

// class TownLifeFindEntityServiceImpl
    @Override
    public TownLife findById(String id) {
        return townLifeRepository.findById(id)
                .orElseThrow(() -> new ResourceNotFoundException(ApiErrorCode.TOWN_LIFE_NOT_FOUND));
    }

// class TownLifeFindCounterServiceImpl
    @Override
    @Transactional
    public TownLifeCounter increaseViewCount(TownLife townLife) {
        TownLifeCounter townLifeCounter = townLifeCounterRepository.findByTownLife(townLife)
                .orElseThrow(() -> new ResourceNotFoundException(ApiErrorCode.TOWN_LIFE_NOT_FOUND));
        return townLifeCounter.view();
    }
```

### ID DESC Indexing
동네생활 탭의 메인 페이지는 동네생활 게시글을 최신순으로 정렬한 리스트를 보여준다.  
최신순으로 정렬하기 위해 `ULID`를 사용하였고, Query에서 `ORDER BY`를 사용하려고 하였다.  
하지만 `ORDER BY`가 데이터 양이 커질 수록 성능을 저해시킨다고 하여 `ORDER BY`를 사용하지 않고 역정렬하는 방식을 고민하였다. 

찾은 해결방법은 indexing이다. 본래 indexing은 빠른 조회를 위해 PK와 특정 column 간의 매핑을 해주는 것이다.  
이를 이용하여 PK이기도 하지만, 저장 순으로 저장되는 PK를 역정렬하여 특정 column과 매핑하였다.

메인 페이지 조회는 동네 ID가 조건이기에, `TownLife` 엔티티에 동네 ID와 게시글 ID의 역정렬을 인덱싱 하였고,
내 게시글 조회는 작성자 ID가 조건이기에, 작성자 ID와 게시글 ID의 역정렬을 인덱싱하였다.

```java
@Table(indexes = {
        @Index(name = "idx__town_life__author_id__id_desc", columnList = "authorId, id DESC"),
        @Index(name = "idx__town_life__town_id__id_desc", columnList = "townId, id DESC"),
}) 
public abstract class TownLife extends BaseEntity 
```

이를 통해 `townId`와 `authorId`를 조건으로 리스트를 가져올 때,  
따로 `ORDER BY .. DESC` 또는 `Collections.reverse(...)`를 하지 않아도 최신순으로 정렬되어 응답되었다.

## Test
![image](https://user-images.githubusercontent.com/42243302/219306720-affda80f-db89-4eed-8408-9111f511d1ff.png)


## Related Files
- `TownLifeFindService`
- `TownLifeFindEntityService`
- `TownLifeFindCounterService`
- `TownLife`
- etc.

## Think About..  
> 인덱싱을 채팅 메시지 서버도 적용해야할까.............;;

## Conclusion  
> close GM-270
