### PR TITLE
GM-291 admin category remove service impl

### DIFF
--- a/src/main/java/com/gaaji/townlife/service/applicationservice/admin/AdminCategoryModifyServiceImpl.java
+++ b/src/main/java/com/gaaji/townlife/service/applicationservice/admin/AdminCategoryModifyServiceImpl.java
@@ -27,12 +27,12 @@ public class AdminCategoryModifyServiceImpl implements AdminCategoryModifyServic
         Category before = Category.create(category.getName(), category.isDefaultCategory(), category.getDescription());
         category.modify(dto.getName(), dto.getDescription(), dto.isDefaultCategory());
 
-        Function<Category, CategoryUpdatedEventBody.CategoryDto> createEventDto = c ->
+        Function<Category, CategoryUpdatedEventBody.CategoryDto> createEventDtoFunc = c ->
                 new CategoryUpdatedEventBody.CategoryDto(c.getName(), c.getDescription(), c.isDefaultCategory());
         eventPublisher.publishEvent(new CategoryUpdatedEvent(this, new CategoryUpdatedEventBody(
                 category.getId(),
-                createEventDto.apply(before),
-                createEventDto.apply(category)
+                createEventDtoFunc.apply(before),
+                createEventDtoFunc.apply(category)
         )));
     }
 

--- a/src/main/java/com/gaaji/townlife/service/applicationservice/admin/AdminCategoryRemoveServiceImpl.java
+++ b/src/main/java/com/gaaji/townlife/service/applicationservice/admin/AdminCategoryRemoveServiceImpl.java
@@ -1,0 +1,35 @@
+package com.gaaji.townlife.service.applicationservice.admin;
+
+import com.gaaji.townlife.service.domain.category.Category;
+import com.gaaji.townlife.service.event.CategoryDeletedEvent;
+import com.gaaji.townlife.service.event.dto.CategoryDeletedEventBody;
+import com.gaaji.townlife.service.repository.CategoryRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class AdminCategoryRemoveServiceImpl implements AdminCategoryRemoveService {
+    private final CategoryRepository categoryRepository;
+    private final ApplicationEventPublisher eventPublisher;
+
+    @Override
+    public void remove(String categoryId) {
+        Optional<Category> categoryOptional = categoryRepository.findById(categoryId);
+        if(categoryOptional.isEmpty()) return;
+        Category category = categoryOptional.get();
+        categoryRepository.delete(category);
+
+        eventPublisher.publishEvent(new CategoryDeletedEvent(this, new CategoryDeletedEventBody(
+                category.getId(),
+                category.getName(),
+                category.getDescription(),
+                category.isDefaultCategory()
+        )));
+    }
+}

--- a/src/main/java/com/gaaji/townlife/service/controller/admin/AdminController.java
+++ b/src/main/java/com/gaaji/townlife/service/controller/admin/AdminController.java
@@ -2,6 +2,7 @@ package com.gaaji.townlife.service.controller.admin;
 
 import com.gaaji.townlife.service.applicationservice.admin.AdminCategoryFindService;
 import com.gaaji.townlife.service.applicationservice.admin.AdminCategoryModifyService;
+import com.gaaji.townlife.service.applicationservice.admin.AdminCategoryRemoveService;
 import com.gaaji.townlife.service.applicationservice.admin.AdminCategorySaveService;
 import com.gaaji.townlife.service.controller.admin.dto.AdminCategoryListDto;
 import com.gaaji.townlife.service.controller.admin.dto.AdminCategoryModifyDto;
@@ -20,6 +21,7 @@ public class AdminController {
     private final AdminCategorySaveService saveService;
     private final AdminCategoryFindService findService;
     private final AdminCategoryModifyService modifyService;
+    private final AdminCategoryRemoveService removeService;
 
     @PostMapping("/categories")
     @ResponseStatus(HttpStatus.CREATED)
@@ -37,5 +39,10 @@ public class AdminController {
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void categoryModify(@PathVariable String categoryId, @RequestBody AdminCategoryModifyDto dto) {
         modifyService.modify(categoryId, dto);
+    }
+
+    @DeleteMapping("/categories/{categoryId}")
+    public void categoryRemove(@PathVariable String categoryId) {
+        removeService.remove(categoryId);
     }
 }

--- a/src/main/java/com/gaaji/townlife/service/event/CategoryDeletedEvent.java
+++ b/src/main/java/com/gaaji/townlife/service/event/CategoryDeletedEvent.java
@@ -1,0 +1,9 @@
+package com.gaaji.townlife.service.event;
+
+import com.gaaji.townlife.service.event.dto.CategoryDeletedEventBody;
+
+public class CategoryDeletedEvent extends KafkaEventBase<CategoryDeletedEventBody> {
+    public CategoryDeletedEvent(Object source, CategoryDeletedEventBody body) {
+        super(source, "townLife-categoryCreated", body);
+    }
+}

--- a/src/main/java/com/gaaji/townlife/service/event/dto/CategoryDeletedEventBody.java
+++ b/src/main/java/com/gaaji/townlife/service/event/dto/CategoryDeletedEventBody.java
@@ -1,0 +1,15 @@
+package com.gaaji.townlife.service.event.dto;
+
+public class CategoryDeletedEventBody {
+    private final String id;
+    private final String name;
+    private final String description;
+    private final boolean isDefault;
+
+    public CategoryDeletedEventBody(String id, String name, String description, boolean isDefault) {
+        this.id = id;
+        this.name = name;
+        this.description = description;
+        this.isDefault = isDefault;
+    }
+}

--- a/src/test/java/com/gaaji/townlife/service/applicationservice/admin/AdminCategoryServiceTest.java
+++ b/src/test/java/com/gaaji/townlife/service/applicationservice/admin/AdminCategoryServiceTest.java
@@ -34,6 +34,8 @@ class AdminCategoryServiceTest {
     @Autowired
     AdminCategoryModifyService adminCategoryModifyService;
     @Autowired
+    AdminCategoryRemoveService adminCategoryRemoveService;
+    @Autowired
     CategoryRepository categoryRepository;
 
     @Test
@@ -91,6 +93,20 @@ class AdminCategoryServiceTest {
             Assertions.assertEquals(randomDescription, modified.getDescription());
             Assertions.assertEquals(randomBoolean, modified.isDefaultCategory());
         });
+    }
+
+    @Test
+    void 카테고리_삭제() {
+        // given
+        final int categoryCount = 10;
+        List<Category> savedCategories = IntStream.range(0, categoryCount).mapToObj(i -> randomCategory()).collect(Collectors.toList());
+
+        // when
+        savedCategories.forEach(category -> adminCategoryRemoveService.remove(category.getId()));
+
+        // then
+        List<AdminCategoryListDto> list = adminCategoryFindService.findList();
+        Assertions.assertTrue(list.isEmpty());
     }
 
     Category randomCategory() {


### PR DESCRIPTION
# GM-291 admin category remove service impl
## Description
GM-291 admin category remove service impl

## PR Type
- [ ] Hotfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor (code, package, etc.)
- [ ] Build (gradle, spring, etc) 
- [ ] Documentation content changes (api docs, etc.)
- [ ] Infra (cloud, security, etc.)
- [ ] Other... Please describe :


## Issues
```java
    @Override
    public void remove(String categoryId) {
        Optional<Category> categoryOptional = categoryRepository.findById(categoryId);
        if(categoryOptional.isEmpty()) return;
        Category category = categoryOptional.get();
        categoryRepository.delete(category);

        eventPublisher.publishEvent(new CategoryDeletedEvent(this, new CategoryDeletedEventBody(
                category.getId(),
                category.getName(),
                category.getDescription(),
                category.isDefaultCategory()
        )));
    }
```

## Test

```java
    @Test
    void 카테고리_삭제() {
        // given
        final int categoryCount = 10;
        List<Category> savedCategories = IntStream.range(0, categoryCount).mapToObj(i -> randomCategory()).collect(Collectors.toList());

        // when
        savedCategories.forEach(category -> adminCategoryRemoveService.remove(category.getId()));

        // then
        List<AdminCategoryListDto> list = adminCategoryFindService.findList();
        Assertions.assertTrue(list.isEmpty());
    }
```
