### PR TITLE
HotFix:: find 서비스 Paging 로직 변경

### DIFF
--- a/src/main/java/com/gaaji/townlife/service/applicationservice/townlife/TownLifeFindEntityService.java
+++ b/src/main/java/com/gaaji/townlife/service/applicationservice/townlife/TownLifeFindEntityService.java
@@ -1,19 +1,12 @@
 package com.gaaji.townlife.service.applicationservice.townlife;
 
 import com.gaaji.townlife.service.domain.townlife.TownLife;
-
-import java.util.List;
+import org.springframework.data.domain.Slice;
 
 public interface TownLifeFindEntityService {
 
     TownLife findById(String id);
-
-    List<TownLife> findListByTownId(String townId, int size);
-
-    List<TownLife> findMoreListByTownIdAndIdLessThan(String townId, String lastTownLifeId, int size);
-
-    List<TownLife> findListByAuthorId(String authorId, int size);
-
-    List<TownLife> findMoreListByAuthorIdAndIdLessThan(String authorId, String lastTownLifeId, int size);
+    Slice<TownLife> findListByTownIdAndIdLessThan(String townId, String offsetTownLifeId, int page, int size);
+    Slice<TownLife> findListByUserIdAndIdLessThan(String userId, String offsetTownLifeId, int page, int size);
 
 }

--- a/src/main/java/com/gaaji/townlife/service/applicationservice/townlife/TownLifeFindEntityServiceImpl.java
+++ b/src/main/java/com/gaaji/townlife/service/applicationservice/townlife/TownLifeFindEntityServiceImpl.java
@@ -7,6 +7,7 @@ import com.gaaji.townlife.service.repository.TownLifeRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -20,51 +21,28 @@ public class TownLifeFindEntityServiceImpl implements TownLifeFindEntityService 
 
     @Override
     public TownLife findById(String id) {
-
         return townLifeRepository.findById(id)
                 .orElseThrow(() -> new ResourceNotFoundException(ApiErrorCode.TOWN_LIFE_NOT_FOUND));
     }
 
     @Override
-    public List<TownLife> findListByTownId(String townId, int size) {
+    public Slice<TownLife> findListByTownIdAndIdLessThan(String townId, String offsetTownLifeId, int page, int size) {
 
-        PageRequest page = PageRequest.ofSize(size);
-        List<TownLife> townLives = townLifeRepository.findByTownId(townId, page);
+        PageRequest paging = PageRequest.of(page, size);
+        Slice<TownLife> townLives = townLifeRepository.findByTownIdAndIdLessThan(townId, offsetTownLifeId, paging);
 
-        validateExistTownLives(townLives);
-
-        return townLives;
-    }
-
-    @Override
-    public List<TownLife> findMoreListByTownIdAndIdLessThan(String townId, String lastTownLifeId, int size) {
-
-        PageRequest page = PageRequest.ofSize(size);
-        List<TownLife> townLives = townLifeRepository.findByTownIdAndIdLessThan(townId, lastTownLifeId, page);
-
-        validateExistTownLives(townLives);
+        validateExistTownLives(townLives.getContent());
 
         return townLives;
     }
 
     @Override
-    public List<TownLife> findListByAuthorId(String authorId, int size) {
+    public Slice<TownLife> findListByUserIdAndIdLessThan(String userId, String offsetTownLifeId, int page, int size) {
 
-        PageRequest page = PageRequest.ofSize(size);
-        List<TownLife> townLives = townLifeRepository.findByAuthorId(authorId, page);
+        PageRequest paging = PageRequest.of(page, size);
+        Slice<TownLife> townLives = townLifeRepository.findByAuthorIdAndIdLessThan(userId, offsetTownLifeId, paging);
 
-        validateExistTownLives(townLives);
-
-        return townLives;
-    }
-
-    @Override
-    public List<TownLife> findMoreListByAuthorIdAndIdLessThan(String authorId, String lastTownLifeId, int size) {
-
-        PageRequest page = PageRequest.ofSize(size);
-        List<TownLife> townLives = townLifeRepository.findByAuthorIdAndIdLessThan(authorId, lastTownLifeId, page);
-
-        validateExistTownLives(townLives);
+        validateExistTownLives(townLives.getContent());
 
         return townLives;
     }

--- a/src/main/java/com/gaaji/townlife/service/applicationservice/townlife/TownLifeFindService.java
+++ b/src/main/java/com/gaaji/townlife/service/applicationservice/townlife/TownLifeFindService.java
@@ -1,15 +1,15 @@
 package com.gaaji.townlife.service.applicationservice.townlife;
 
 import com.gaaji.townlife.service.controller.townlife.dto.TownLifeDetailDto;
-import com.gaaji.townlife.service.controller.townlife.dto.TownLifeListDto;
+import com.gaaji.townlife.service.controller.townlife.dto.TownLifeListResponseDto;
 
-import java.util.List;
+import java.time.LocalDateTime;
 
 public interface TownLifeFindService {
 
     TownLifeDetailDto findById(String id);
     TownLifeDetailDto visit(String id);
-    List<TownLifeListDto> findListByTownId(String townId, String lastTownLifeId, int size);
-    List<TownLifeListDto> findListByUserId(String userId, String lastTownLifeId, int size);
+    TownLifeListResponseDto findListByTownId(String townId, LocalDateTime requestTime, int page, int size);
+    TownLifeListResponseDto findListByUserId(String userId, LocalDateTime requestTime, int page, int size);
 
 }

--- a/src/main/java/com/gaaji/townlife/service/controller/townlife/dto/TownLifeListDto.java
+++ b/src/main/java/com/gaaji/townlife/service/controller/townlife/dto/TownLifeListDto.java
@@ -14,6 +14,7 @@ public class TownLifeListDto {
 
     private String id;
     private String categoryId;
+    private String authorId;
     private String categoryName;
     private String townId;
     private String title;
@@ -27,6 +28,7 @@ public class TownLifeListDto {
                 .id(entity.getId())
                 .categoryId(entity.getCategory().getId())
                 .categoryName(entity.getCategory().getName())
+                .authorId(entity.getAuthorId())
                 .townId(entity.getTownId())
                 .title(entity.getContent().getTitle())
                 .createdAt(entity.getCreatedAt())

--- a/src/main/java/com/gaaji/townlife/service/controller/townlife/dto/TownLifeListResponseDto.java
+++ b/src/main/java/com/gaaji/townlife/service/controller/townlife/dto/TownLifeListResponseDto.java
@@ -1,0 +1,33 @@
+package com.gaaji.townlife.service.controller.townlife.dto;
+
+import com.gaaji.townlife.service.domain.townlife.TownLife;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+import org.springframework.data.domain.Slice;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Getter @ToString
+@NoArgsConstructor
+@AllArgsConstructor
+public class TownLifeListResponseDto {
+
+    private List<TownLifeListDto> content;
+    private Boolean hasNext;
+
+    public static TownLifeListResponseDto of(Slice<TownLife> townLives) {
+        return new TownLifeListResponseDto(
+                convertContentFromEntityList(townLives.getContent()),
+                townLives.hasNext()
+        );
+    }
+
+    private static List<TownLifeListDto> convertContentFromEntityList(List<TownLife> townLives) {
+        return townLives.stream()
+                .map(townLife -> TownLifeListDto.of(townLife, townLife.getTownLifeCounter()))
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/com/gaaji/townlife/service/domain/category/Category.java
+++ b/src/main/java/com/gaaji/townlife/service/domain/category/Category.java
@@ -1,6 +1,7 @@
 package com.gaaji.townlife.service.domain.category;
 
 import com.gaaji.townlife.service.domain.townlife.TownLife;
+import com.gaaji.townlife.service.domain.townlife.TownLifeType;
 import lombok.*;
 import org.hibernate.annotations.GenericGenerator;
 
@@ -9,7 +10,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 @Entity
-@Getter @ToString
+@Getter @ToString(exclude = {"subscriptions", "townLives"})
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Table(indexes = {
@@ -27,15 +28,18 @@ public class Category {
     private List<CategorySubscription> subscriptions = new ArrayList<>();
     @OneToMany(mappedBy = "category")
     private List<TownLife> townLives = new ArrayList<>();
+    @Enumerated(EnumType.STRING)
+    private TownLifeType townLifeType;
 
-    private Category(String name, boolean isDefault, String description) {
+    private Category(String name, boolean isDefault, String description, TownLifeType townLifeType) {
         this.name = name;
         this.isDefault = isDefault;
         this.description = description;
+        this.townLifeType = townLifeType;
     }
 
-    public static Category create(String name, boolean isDefault, String description) {
-        return new Category(name, isDefault, description);
+    public static Category create(String name, boolean isDefault, String description, TownLifeType townLifeType) {
+        return new Category(name, isDefault, description, townLifeType);
     }
 
     public Category addTownLife(TownLife townLife) {

--- a/src/main/java/com/gaaji/townlife/service/repository/TownLifeRepository.java
+++ b/src/main/java/com/gaaji/townlife/service/repository/TownLifeRepository.java
@@ -2,19 +2,12 @@ package com.gaaji.townlife.service.repository;
 
 import com.gaaji.townlife.service.domain.townlife.TownLife;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
-
-import java.util.List;
 
 public interface TownLifeRepository extends JpaRepository<TownLife, String> {
 
-
-    List<TownLife> findByTownId(String townId, Pageable pageable);
-
-    List<TownLife> findByTownIdAndIdLessThan(String townId, String id, Pageable pageable);
-
-    List<TownLife> findByAuthorId(String authorId, Pageable pageable);
-
-    List<TownLife> findByAuthorIdAndIdLessThan(String authorId, String id, Pageable pageable);
+    Slice<TownLife> findByTownIdAndIdLessThan(String townId, String id, Pageable pageable);
+    Slice<TownLife> findByAuthorIdAndIdLessThan(String authorId, String id, Pageable pageable);
 
 }

--- a/src/test/java/com/gaaji/townlife/service/repository/CategoryRepositoryTest.java
+++ b/src/test/java/com/gaaji/townlife/service/repository/CategoryRepositoryTest.java
@@ -1,6 +1,7 @@
 package com.gaaji.townlife.service.repository;
 
 import com.gaaji.townlife.service.domain.category.Category;
+import com.gaaji.townlife.service.domain.townlife.TownLifeType;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -15,7 +16,7 @@ class CategoryRepositoryTest {
 
     @Test
     void 카테고리_저장() {
-        Category category = Category.create("테스트 카테고리", true, "테스트 카테고리입니다.");
+        Category category = Category.create("테스트 카테고리", true, "테스트 카테고리입니다.", TownLifeType.POST);
         Category created = categoryRepository.save(category);
 
         Assertions.assertNotNull(created);


### PR DESCRIPTION
# HotFix:: find 서비스 Paging 로직 변경
## Description
> 기존 Paging 시, List로 응답하고, `lastTownLifeId`를 클라이언트로부터 요청받아 offset으로 적용하였는데, 
> List에서 Slice로 변경하고, 클라이언트로부터 `requestTime`을 요청받고, `hasNext`를 통해 무한 스크롤을 구현함.

## PR Type
- [x] Hotfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor (code, package, etc.)
- [ ] Build (gradle, spring, etc) 
- [ ] Documentation content changes (api docs, etc.)
- [ ] Infra (cloud, security, etc.)
- [ ] Other... Please describe :

## Related Issues
- GM-262
- PR #10 

## Issues
### Slice로 변경
기존에는 클라이언트로부터 `lastTownLifeId`를 요청받았는데, 만일 초기 화면이면 `-1`을 받고, 추가 호출이면 마지막 동네생활 게시글 ID를 요청받아서 이를 offset으로 페이징하였다.

하지만 계속 변경되는 게시글 ID에 대하여 클라이언트 로직의 불편함과 요청에 대한 신뢰도 이슈로 인해, 클라이언트로부터는 요청일자 `LocalDateTime requestTime`을 받는 것으로 변경하였다.

기존 로직의 수정을 최소화하고, `ULID` 기반으로 시간 순이 보장되는 ID의 역정렬화 Indexing을 사용하기 위해, 
`requestTime`을 `ULID`로 생성하여, `find...By...IdLessThan`을 사용할 수 있었다.

 ```java
// class TownLifeFindServiceImpl
    @Override
    @Transactional
    public TownLifeListResponseDto findListByTownId(String townId, LocalDateTime requestTime, int page, int size) {
        String offsetId = new ULID().nextULID(requestTime.toInstant(ZoneOffset.UTC).toEpochMilli());
        Slice<TownLife> townLives = entityService.findListByTownIdAndIdLessThan(townId, offsetId, page, size);
        return TownLifeListResponseDto.of(townLives);
    }
    @Override
    @Transactional
    public TownLifeListResponseDto findListByUserId(String userId, LocalDateTime requestTime, int page, int size) {
        String offsetId = new ULID().nextULID(requestTime.toInstant(ZoneOffset.UTC).toEpochMilli());
        Slice<TownLife> townLives = entityService.findListByUserIdAndIdLessThan(userId, offsetId, page, size);
        return TownLifeListResponseDto.of(townLives);
    }
```

```java
// interface TownLifeFindEntityService
    Slice<TownLife> findListByTownIdAndIdLessThan(String townId, String offsetTownLifeId, int page, int size);
    Slice<TownLife> findListByUserIdAndIdLessThan(String userId, String offsetTownLifeId, int page, int size);
```

### DTO 정의
위의 요청에 대한 응답 DTO는 다음과 같다.

```java
public class TownLifeListResponseDto {

    private List<TownLifeListDto> content;
    private Boolean hasNext;

}

public class TownLifeListDto {

    private String id;
    private String categoryId;
    private String authorId;
    private String categoryName;
    private String townId;
    private String title;
    private LocalDateTime createdAt;
    private int commentCount;
    private int reactionCount;
    private String thumbnailSrc;

}
```

## Test
### 페이징 3회 테스트
![image](https://user-images.githubusercontent.com/42243302/219573654-5f45f5c3-d639-408e-9943-5cfedf1ac740.png)

## Related Files
- `TownLifeFindService`
- `TownLifeFindEntityService`

## Think About..  
> 

## Conclusion  
> 
