### PR TITLE
GM-316 impl comment modify service

### DIFF
--- a/src/main/java/com/gaaji/townlife/global/exceptions/api/ApiErrorCode.java
+++ b/src/main/java/com/gaaji/townlife/global/exceptions/api/ApiErrorCode.java
@@ -25,7 +25,10 @@ public enum ApiErrorCode implements ErrorCode {
     IMAGE_CONTENT_TYPE_ERROR(HttpStatus.BAD_REQUEST, "TL-0016", "업로드하실 파일은 이미지 파일만 가능합니다."),
     IMAGE_NOT_FOUND(HttpStatus.BAD_REQUEST, "TL-0017", "업로드한 이미지가 없습니다."),
     BAD_REQUEST(HttpStatus.BAD_REQUEST, "TL-0018", "잘못된 요청입니다."),
-    COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "TL-0019", "Comment 리소스를 찾을 수 없습니다.");
+    COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "TL-0019", "Comment 리소스를 찾을 수 없습니다."),
+    NOT_YOUR_RESOURCE(HttpStatus.FORBIDDEN, "TL-0020", "요청자가 접근할 수 없는 리소스입니다."),
+
+    ;
 
 
     ;

--- a/src/main/java/com/gaaji/townlife/global/exceptions/api/exception/NotYourResourceException.java
+++ b/src/main/java/com/gaaji/townlife/global/exceptions/api/exception/NotYourResourceException.java
@@ -1,0 +1,16 @@
+package com.gaaji.townlife.global.exceptions.api.exception;
+
+import com.gaaji.townlife.global.exceptions.api.AbstractApiException;
+import com.gaaji.townlife.global.exceptions.api.ApiErrorCode;
+import com.gaaji.townlife.global.exceptions.api.ErrorCode;
+
+public class NotYourResourceException extends AbstractApiException {
+
+    public NotYourResourceException(String message) {
+        super(ApiErrorCode.NOT_YOUR_RESOURCE, message);
+    }
+
+    public NotYourResourceException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/gaaji/townlife/service/applicationservice/comment/CommentLikeServiceImpl.java
+++ b/src/main/java/com/gaaji/townlife/service/applicationservice/comment/CommentLikeServiceImpl.java
@@ -1,9 +1,7 @@
 package com.gaaji.townlife.service.applicationservice.comment;
 
 import com.gaaji.townlife.global.exceptions.api.ApiErrorCode;
-import com.gaaji.townlife.global.exceptions.api.exception.BadRequestException;
 import com.gaaji.townlife.global.exceptions.api.exception.ResourceNotFoundException;
-import com.gaaji.townlife.service.controller.comment.dto.CommentLikeRequestDto;
 import com.gaaji.townlife.service.domain.comment.Comment;
 import com.gaaji.townlife.service.domain.comment.CommentLike;
 import com.gaaji.townlife.service.event.CommentLikeCreatedEvent;
@@ -54,8 +52,7 @@ public class CommentLikeServiceImpl implements CommentLikeService {
     }
 
     private Comment findCommentById(String commentId) {
-        Comment comment = commentRepository.findById(commentId).orElseThrow(() -> new ResourceNotFoundException(ApiErrorCode.COMMENT_NOT_FOUND));
-        return comment;
+        return commentRepository.findById(commentId).orElseThrow(() -> new ResourceNotFoundException(ApiErrorCode.COMMENT_NOT_FOUND));
     }
 
     private void checkTownLifeExists(String townLifeId) {

--- a/src/main/java/com/gaaji/townlife/service/applicationservice/comment/CommentModifyService.java
+++ b/src/main/java/com/gaaji/townlife/service/applicationservice/comment/CommentModifyService.java
@@ -1,10 +1,10 @@
 package com.gaaji.townlife.service.applicationservice.comment;
 
+import com.gaaji.townlife.service.controller.comment.dto.CommentListDto;
 import com.gaaji.townlife.service.controller.comment.dto.CommentModifyRequestDto;
-import com.gaaji.townlife.service.controller.comment.dto.CommentModifyResponseDto;
 
 public interface CommentModifyService {
 
-    CommentModifyResponseDto modify(String townLifeId, String commentId, CommentModifyRequestDto dto);
+    CommentListDto modify(String authId, String townLifeId, String commentId, CommentModifyRequestDto dto);
 
 }

--- a/src/main/java/com/gaaji/townlife/service/applicationservice/comment/CommentModifyServiceImpl.java
+++ b/src/main/java/com/gaaji/townlife/service/applicationservice/comment/CommentModifyServiceImpl.java
@@ -1,0 +1,43 @@
+package com.gaaji.townlife.service.applicationservice.comment;
+
+import com.gaaji.townlife.global.exceptions.api.ApiErrorCode;
+import com.gaaji.townlife.global.exceptions.api.exception.NotYourResourceException;
+import com.gaaji.townlife.global.exceptions.api.exception.ResourceNotFoundException;
+import com.gaaji.townlife.service.controller.comment.dto.CommentListDto;
+import com.gaaji.townlife.service.controller.comment.dto.CommentModifyRequestDto;
+import com.gaaji.townlife.service.domain.comment.Comment;
+import com.gaaji.townlife.service.domain.comment.CommentContent;
+import com.gaaji.townlife.service.repository.CommentRepository;
+import com.gaaji.townlife.service.repository.TownLifeRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class CommentModifyServiceImpl implements CommentModifyService {
+    private final CommentRepository commentRepository;
+    private final TownLifeRepository townLifeRepository;
+
+    @Override
+    public CommentListDto modify(String authId, String townLifeId, String commentId, CommentModifyRequestDto dto) {
+        checkTownLifeExists(townLifeId);
+        Comment comment = findCommentById(commentId);
+        if(!comment.getUserId().equals(authId))
+            throw new NotYourResourceException("요청자가 작성하지 않은 Comment를 Modify할 수 없습니다.");
+
+        comment.modify(CommentContent.create(dto.getText(), dto.getLocation()));
+        return CommentListDto.of(comment);
+    }
+
+    private void checkTownLifeExists(String townLifeId) {
+        if(!townLifeRepository.existsById(townLifeId))
+            throw new ResourceNotFoundException(ApiErrorCode.TOWN_LIFE_NOT_FOUND);
+    }
+
+    private Comment findCommentById(String commentId) {
+        Comment comment = commentRepository.findById(commentId).orElseThrow(() -> new ResourceNotFoundException(ApiErrorCode.COMMENT_NOT_FOUND));
+        return comment;
+    }
+}

--- a/src/main/java/com/gaaji/townlife/service/applicationservice/comment/CommentModifyServiceImpl.java
+++ b/src/main/java/com/gaaji/townlife/service/applicationservice/comment/CommentModifyServiceImpl.java
@@ -37,7 +37,6 @@ public class CommentModifyServiceImpl implements CommentModifyService {
     }
 
     private Comment findCommentById(String commentId) {
-        Comment comment = commentRepository.findById(commentId).orElseThrow(() -> new ResourceNotFoundException(ApiErrorCode.COMMENT_NOT_FOUND));
-        return comment;
+        return  commentRepository.findById(commentId).orElseThrow(() -> new ResourceNotFoundException(ApiErrorCode.COMMENT_NOT_FOUND));
     }
 }

--- a/src/main/java/com/gaaji/townlife/service/controller/comment/CommentController.java
+++ b/src/main/java/com/gaaji/townlife/service/controller/comment/CommentController.java
@@ -1,11 +1,9 @@
 package com.gaaji.townlife.service.controller.comment;
 
 import com.gaaji.townlife.service.applicationservice.comment.CommentFindService;
+import com.gaaji.townlife.service.applicationservice.comment.CommentModifyService;
 import com.gaaji.townlife.service.applicationservice.comment.CommentSaveService;
-import com.gaaji.townlife.service.controller.comment.dto.ChildCommentListDto;
-import com.gaaji.townlife.service.controller.comment.dto.CommentSaveRequestDto;
-import com.gaaji.townlife.service.controller.comment.dto.CommentSaveResponseDto;
-import com.gaaji.townlife.service.controller.comment.dto.ParentCommentListDto;
+import com.gaaji.townlife.service.controller.comment.dto.*;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
@@ -19,6 +17,7 @@ import java.util.List;
 public class CommentController {
     private final CommentSaveService commentSaveService;
     private final CommentFindService commentFindService;
+    private final CommentModifyService commentModifyService;
 
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
@@ -56,6 +55,16 @@ public class CommentController {
             @RequestParam(required = false) Integer size
     ) {
         return commentFindService.findChildCommentListByParentCommentId(postId, parentId, lastCommentId, size);
+    }
+
+    @PutMapping("/{commentId}")
+    @ResponseStatus(HttpStatus.CREATED)
+    public CommentListDto commentModify(
+            @RequestHeader(HttpHeaders.AUTHORIZATION) String authId,
+            @PathVariable String postId,
+            @PathVariable String commentId,
+            @RequestBody CommentModifyRequestDto dto) {
+        return commentModifyService.modify(authId, postId, commentId, dto);
     }
 }
 

--- a/src/main/java/com/gaaji/townlife/service/controller/comment/dto/CommentModifyRequestDto.java
+++ b/src/main/java/com/gaaji/townlife/service/controller/comment/dto/CommentModifyRequestDto.java
@@ -1,4 +1,19 @@
 package com.gaaji.townlife.service.controller.comment.dto;
 
+import lombok.Getter;
+
+import javax.validation.constraints.NotBlank;
+
+@Getter
 public class CommentModifyRequestDto {
+    private String location;
+    @NotBlank
+    private String text;
+
+    public static CommentModifyRequestDto create(String text, String location) {
+        CommentModifyRequestDto dto = new CommentModifyRequestDto();
+        dto.text = text;
+        dto.location = location;
+        return dto;
+    }
 }

--- a/src/main/java/com/gaaji/townlife/service/domain/comment/Comment.java
+++ b/src/main/java/com/gaaji/townlife/service/domain/comment/Comment.java
@@ -41,4 +41,11 @@ public abstract class Comment extends BaseEntity {
     public void removeLike(CommentLike like) {
         this.likes.remove(like);
     }
+
+    public void modify(CommentContent content) {
+        if(content.getText().equals(this.content.getText()))
+            if(content.getLocation().equals(this.content.getLocation()))
+                return;
+        this.content = content;
+    }
 }

--- a/src/test/java/com/gaaji/townlife/service/applicationservice/comment/CommentServiceTest.java
+++ b/src/test/java/com/gaaji/townlife/service/applicationservice/comment/CommentServiceTest.java
@@ -1,6 +1,7 @@
 package com.gaaji.townlife.service.applicationservice.comment;
 
 import com.gaaji.townlife.global.exceptions.api.exception.BadRequestException;
+import com.gaaji.townlife.global.exceptions.api.exception.NotYourResourceException;
 import com.gaaji.townlife.global.exceptions.api.exception.ResourceNotFoundException;
 import com.gaaji.townlife.service.applicationservice.admin.AdminCategorySaveService;
 import com.gaaji.townlife.service.applicationservice.townlife.TownLifeSaveService;
@@ -190,6 +191,28 @@ public class CommentServiceTest {
             Assertions.assertEquals(expected.getContent().getText(), actual.getText());
             Assertions.assertEquals(expected.getContent().getImageSrc(), actual.getImageSrc());
         });
+    }
+
+    @Autowired
+    CommentModifyService commentModifyService;
+
+    @Test
+    void 댓글_수정() {
+        Category category = randomCategory();
+        TownLife townLife = randomTownLife(category);
+        String commenterId = randomString();
+        ParentComment parentComment = randomParentComment(townLife, commenterId);
+        String toBeText = randomString();
+        String toBeLocation = randomString();
+        CommentModifyRequestDto toBeDto = CommentModifyRequestDto.create(toBeText, toBeLocation);
+
+        CommentListDto actual = commentModifyService.modify(commenterId, townLife.getId(), parentComment.getId(), toBeDto);
+
+        Assertions.assertEquals(toBeText, actual.getText());
+        Assertions.assertEquals(toBeLocation, actual.getLocation());
+
+        String otherId = randomString();
+        Assertions.assertThrows(NotYourResourceException.class, () -> commentModifyService.modify(otherId, townLife.getId(), parentComment.getId(), toBeDto));
     }
 
     @Autowired


### PR DESCRIPTION
# GM-316 impl comment modify service
## Description
comment의 text와 location을 수정한다.
이미지는 다른 엔드포인트를 통해 수정한다.
이벤트 없음.

## PR Type
- [ ] Hotfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor (code, package, etc.)
- [ ] Build (gradle, spring, etc) 
- [ ] Documentation content changes (api docs, etc.)
- [ ] Infra (cloud, security, etc.)
- [ ] Other... Please describe :

## Issues
```java
// service
    @Override
    public CommentListDto modify(String authId, String townLifeId, String commentId, CommentModifyRequestDto dto) {
        checkTownLifeExists(townLifeId);
        Comment comment = findCommentById(commentId);
        if(!comment.getUserId().equals(authId))
            throw new NotYourResourceException("요청자가 작성하지 않은 Comment를 Modify할 수 없습니다.");

        comment.modify(CommentContent.create(dto.getText(), dto.getLocation()));
        return CommentListDto.of(comment);
    }
```
- Check Id of TownLife, Comment in path
- Check if authId equals with Comment.userId

## Test
```java
    @Test
    void 댓글_수정() {
        Category category = randomCategory();
        TownLife townLife = randomTownLife(category);
        String commenterId = randomString();
        ParentComment parentComment = randomParentComment(townLife, commenterId);
        String toBeText = randomString();
        String toBeLocation = randomString();
        CommentModifyRequestDto toBeDto = CommentModifyRequestDto.create(toBeText, toBeLocation);

        CommentListDto actual = commentModifyService.modify(commenterId, townLife.getId(), parentComment.getId(), toBeDto);

        Assertions.assertEquals(toBeText, actual.getText());
        Assertions.assertEquals(toBeLocation, actual.getLocation());

        String otherId = randomString();
        Assertions.assertThrows(NotYourResourceException.class, () -> commentModifyService.modify(otherId, townLife.getId(), parentComment.getId(), toBeDto));
    }
```

