### PR TITLE
GM-320 impl comment remove service

### DIFF
--- a/src/main/java/com/gaaji/townlife/service/applicationservice/comment/CommentRemoveService.java
+++ b/src/main/java/com/gaaji/townlife/service/applicationservice/comment/CommentRemoveService.java
@@ -2,6 +2,6 @@ package com.gaaji.townlife.service.applicationservice.comment;
 
 public interface CommentRemoveService {
 
-    void remove(String townLifeId, String commentId);
+    void remove(String authId, String townLifeId, String commentId);
 
 }

--- a/src/main/java/com/gaaji/townlife/service/applicationservice/comment/CommentRemoveServiceImpl.java
+++ b/src/main/java/com/gaaji/townlife/service/applicationservice/comment/CommentRemoveServiceImpl.java
@@ -1,0 +1,38 @@
+package com.gaaji.townlife.service.applicationservice.comment;
+
+import com.gaaji.townlife.global.exceptions.api.ApiErrorCode;
+import com.gaaji.townlife.global.exceptions.api.exception.NotYourResourceException;
+import com.gaaji.townlife.global.exceptions.api.exception.ResourceNotFoundException;
+import com.gaaji.townlife.service.domain.comment.Comment;
+import com.gaaji.townlife.service.repository.CommentRepository;
+import com.gaaji.townlife.service.repository.TownLifeRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class CommentRemoveServiceImpl implements CommentRemoveService {
+    private final CommentRepository commentRepository;
+    private final TownLifeRepository townLifeRepository;
+
+    @Override
+    public void remove(String authId, String townLifeId, String commentId) {
+        checkTownLifeExists(townLifeId);
+        Comment comment = findCommentById(commentId);
+        if(!comment.getUserId().equals(authId))
+            throw new NotYourResourceException("요청자가 작성하지 않은 Comment를 remove할 수 없습니다.");
+
+        commentRepository.delete(comment); // soft delete. orphanRemover 옵션에 의해 likes는 삭제된다.
+    }
+
+    private void checkTownLifeExists(String townLifeId) {
+        if(!townLifeRepository.existsById(townLifeId))
+            throw new ResourceNotFoundException(ApiErrorCode.TOWN_LIFE_NOT_FOUND);
+    }
+
+    private Comment findCommentById(String commentId) {
+        return  commentRepository.findById(commentId).orElseThrow(() -> new ResourceNotFoundException(ApiErrorCode.COMMENT_NOT_FOUND));
+    }
+}

--- a/src/main/java/com/gaaji/townlife/service/controller/comment/CommentController.java
+++ b/src/main/java/com/gaaji/townlife/service/controller/comment/CommentController.java
@@ -2,6 +2,7 @@ package com.gaaji.townlife.service.controller.comment;
 
 import com.gaaji.townlife.service.applicationservice.comment.CommentFindService;
 import com.gaaji.townlife.service.applicationservice.comment.CommentModifyService;
+import com.gaaji.townlife.service.applicationservice.comment.CommentRemoveService;
 import com.gaaji.townlife.service.applicationservice.comment.CommentSaveService;
 import com.gaaji.townlife.service.controller.comment.dto.*;
 import lombok.RequiredArgsConstructor;
@@ -18,6 +19,7 @@ public class CommentController {
     private final CommentSaveService commentSaveService;
     private final CommentFindService commentFindService;
     private final CommentModifyService commentModifyService;
+    private final CommentRemoveService commentRemoveService;
 
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
@@ -65,6 +67,16 @@ public class CommentController {
             @PathVariable String commentId,
             @RequestBody CommentModifyRequestDto dto) {
         return commentModifyService.modify(authId, postId, commentId, dto);
+    }
+
+    @DeleteMapping("/{commentId}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void commentRemove(
+            @RequestHeader(HttpHeaders.AUTHORIZATION) String authId,
+            @PathVariable String postId,
+            @PathVariable String commentId
+    ) {
+        commentRemoveService.remove(authId, postId, commentId);
     }
 }
 

--- a/src/main/java/com/gaaji/townlife/service/controller/comment/dto/ParentCommentListDto.java
+++ b/src/main/java/com/gaaji/townlife/service/controller/comment/dto/ParentCommentListDto.java
@@ -2,8 +2,12 @@ package com.gaaji.townlife.service.controller.comment.dto;
 
 import com.gaaji.townlife.service.domain.comment.ParentComment;
 import lombok.Getter;
+import lombok.ToString;
+
+import java.time.LocalDateTime;
 
 @Getter
+@ToString
 public class ParentCommentListDto {
     private String id;
     private String commenterId;
@@ -11,6 +15,7 @@ public class ParentCommentListDto {
     private String location;
     private String text;
     private String postId;
+    private LocalDateTime deletedAt;
 
     public static ParentCommentListDto create(ParentComment entity) {
         ParentCommentListDto dto = new ParentCommentListDto();
@@ -20,6 +25,7 @@ public class ParentCommentListDto {
         dto.location = entity.getContent().getLocation();
         dto.text = entity.getContent().getText();
         dto.postId = entity.getTownLife().getId();
+        dto.deletedAt = entity.getDeletedAt();
         return dto;
     }
 }

--- a/src/main/java/com/gaaji/townlife/service/domain/comment/Comment.java
+++ b/src/main/java/com/gaaji/townlife/service/domain/comment/Comment.java
@@ -29,7 +29,7 @@ public abstract class Comment extends BaseEntity {
     @Embedded
     protected CommentContent content;
     protected LocalDateTime deletedAt;
-    @OneToMany(mappedBy = "comment")
+    @OneToMany(mappedBy = "comment", orphanRemoval = true)
     protected List<CommentLike> likes = new ArrayList<>();
 
     public abstract TownLife getTownLife();

--- a/src/main/java/com/gaaji/townlife/service/repository/CommentRepository.java
+++ b/src/main/java/com/gaaji/townlife/service/repository/CommentRepository.java
@@ -10,5 +10,4 @@ import java.util.stream.Stream;
 public interface CommentRepository extends JpaRepository<Comment, String> {
     Stream<Comment> findByUserIdOrderByIdDesc(@NonNull String userId);
 
-    Optional<Comment> findByIdAndDeletedAtIsNotNull(String id);
 }

--- a/src/main/java/com/gaaji/townlife/service/repository/CommentRepository.java
+++ b/src/main/java/com/gaaji/townlife/service/repository/CommentRepository.java
@@ -4,8 +4,11 @@ import com.gaaji.townlife.service.domain.comment.Comment;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.lang.NonNull;
 
+import java.util.Optional;
 import java.util.stream.Stream;
 
 public interface CommentRepository extends JpaRepository<Comment, String> {
     Stream<Comment> findByUserIdOrderByIdDesc(@NonNull String userId);
+
+    Optional<Comment> findByIdAndDeletedAtIsNotNull(String id);
 }

--- a/src/test/java/com/gaaji/townlife/service/applicationservice/comment/CommentServiceTest.java
+++ b/src/test/java/com/gaaji/townlife/service/applicationservice/comment/CommentServiceTest.java
@@ -216,7 +216,24 @@ public class CommentServiceTest {
     }
 
     @Autowired
+    CommentRemoveService commentRemoveService;
+    @Test
+    void 댓글_삭제() {
+        Category category = randomCategory();
+        TownLife townLife = randomTownLife(category);
+        String commenterId = randomString();
+        ParentComment parentComment = randomParentComment(townLife, commenterId);
+
+        commentLikeService.like(commenterId, townLife.getId(), parentComment.getId());
+        commentRemoveService.remove(commenterId, townLife.getId(), parentComment.getId());
+        Comment comment = commentRepository.findByIdAndDeletedAtIsNotNull(parentComment.getId()).get();
+
+        Assertions.assertNotNull(comment.getDeletedAt());
+        Assertions.assertEquals(0, comment.getLikes().size());
+    }
+    @Autowired
     CommentLikeService commentLikeService;
+
 
     @Test
     void 댓글에_좋아요_추가() {

--- a/src/test/java/com/gaaji/townlife/service/applicationservice/comment/CommentServiceTest.java
+++ b/src/test/java/com/gaaji/townlife/service/applicationservice/comment/CommentServiceTest.java
@@ -25,10 +25,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.ArrayList;
-import java.util.Comparator;
-import java.util.List;
-import java.util.UUID;
+import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
@@ -226,7 +223,8 @@ public class CommentServiceTest {
 
         commentLikeService.like(commenterId, townLife.getId(), parentComment.getId());
         commentRemoveService.remove(commenterId, townLife.getId(), parentComment.getId());
-        Comment comment = commentRepository.findByIdAndDeletedAtIsNotNull(parentComment.getId()).get();
+        Assertions.assertTrue(commentRepository.findById(parentComment.getId()).isEmpty());
+        Comment comment = commentRepository.findAllById(Collections.singleton(parentComment.getId())).get(0);
 
         Assertions.assertNotNull(comment.getDeletedAt());
         Assertions.assertEquals(0, comment.getLikes().size());


### PR DESCRIPTION
# GM-320 impl comment remove service
## Description
id에 해당하는 Comment를 삭제한다.
Soft Delete.
CommentLikes are deleted by orphanRemoval option

findById => retrieve only deletedAt is null
findAllById => retrieve all even if deletedAt is null

## PR Type
- [ ] Hotfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor (code, package, etc.)
- [ ] Build (gradle, spring, etc) 
- [ ] Documentation content changes (api docs, etc.)
- [ ] Infra (cloud, security, etc.)
- [ ] Other... Please describe :

## Issues
```java
    @Override
    public void remove(String authId, String townLifeId, String commentId) {
        checkTownLifeExists(townLifeId);
        Comment comment = findCommentById(commentId);
        if(!comment.getUserId().equals(authId))
            throw new NotYourResourceException("요청자가 작성하지 않은 Comment를 remove할 수 없습니다.");

        commentRepository.delete(comment); // soft delete. orphanRemover 옵션에 의해 likes는 삭제된다.
    }
```

## Test
```java
    @Test
    void 댓글_삭제() {
        Category category = randomCategory();
        TownLife townLife = randomTownLife(category);
        String commenterId = randomString();
        ParentComment parentComment = randomParentComment(townLife, commenterId);

        commentLikeService.like(commenterId, townLife.getId(), parentComment.getId());
        commentRemoveService.remove(commenterId, townLife.getId(), parentComment.getId());
        Assertions.assertTrue(commentRepository.findById(parentComment.getId()).isEmpty());
        Comment comment = commentRepository.findAllById(parentComment.getId()).get();

        Assertions.assertNotNull(comment.getDeletedAt());
        Assertions.assertEquals(0, comment.getLikes().size());
    }
```