### PR TITLE
[GM-311] townlife controller 구현

### DIFF
--- a/src/main/java/com/gaaji/townlife/service/applicationservice/townlife/TownLifeImageService.java
+++ b/src/main/java/com/gaaji/townlife/service/applicationservice/townlife/TownLifeImageService.java
@@ -7,8 +7,8 @@ import java.util.List;
 
 public interface TownLifeImageService {
 
-    List<AttachedImageDto> upload(String townLifeId, String authId, int[] orderIndexes, MultipartFile... multipartFiles);
-    List<AttachedImageDto> update(String townLifeId, String authId, int[] orderIndexes, MultipartFile... multipartFiles);
-    List<AttachedImageDto> deleteAll(String townLifeId, String authId);
+    List<AttachedImageDto> upload(String authId, String townLifeId, int[] orderIndexes, MultipartFile... multipartFiles);
+    List<AttachedImageDto> update(String authId, String townLifeId, int[] orderIndexes, MultipartFile... multipartFiles);
+    List<AttachedImageDto> deleteAll(String authId, String townLifeId);
 
 }

--- a/src/main/java/com/gaaji/townlife/service/applicationservice/townlife/TownLifeImageServiceImpl.java
+++ b/src/main/java/com/gaaji/townlife/service/applicationservice/townlife/TownLifeImageServiceImpl.java
@@ -33,7 +33,7 @@ public class TownLifeImageServiceImpl implements TownLifeImageService {
 
     @Override
     @Transactional
-    public List<AttachedImageDto> upload(String townLifeId, String authId, int[] orderIndexes, MultipartFile... multipartFiles) {
+    public List<AttachedImageDto> upload(String authId, String townLifeId, int[] orderIndexes, MultipartFile... multipartFiles) {
         TownLife townLife = prepareUpload(townLifeId, authId, orderIndexes, multipartFiles);
 
         upload(townLife, orderIndexes, multipartFiles);
@@ -43,7 +43,7 @@ public class TownLifeImageServiceImpl implements TownLifeImageService {
 
     @Override
     @Transactional
-    public List<AttachedImageDto> update(String townLifeId, String authId, int[] orderIndexes, MultipartFile... multipartFiles) {
+    public List<AttachedImageDto> update(String authId, String townLifeId, int[] orderIndexes, MultipartFile... multipartFiles) {
         TownLife townLife = prepareUpload(townLifeId, authId, orderIndexes, multipartFiles);
 
         deleteAll(townLife);
@@ -55,7 +55,7 @@ public class TownLifeImageServiceImpl implements TownLifeImageService {
 
     @Override
     @Transactional
-    public List<AttachedImageDto> deleteAll(String townLifeId, String authId) {
+    public List<AttachedImageDto> deleteAll(String authId, String townLifeId) {
         TownLife townLife = prepare(townLifeId, authId);
 
         deleteAll(townLife);

--- a/src/main/java/com/gaaji/townlife/service/applicationservice/townlife/TownLifeRemoveService.java
+++ b/src/main/java/com/gaaji/townlife/service/applicationservice/townlife/TownLifeRemoveService.java
@@ -2,6 +2,6 @@ package com.gaaji.townlife.service.applicationservice.townlife;
 
 public interface TownLifeRemoveService {
 
-    void remove(String townLifeId, String authorId);
+    void remove(String authId, String townLifeId);
 
 }

--- a/src/main/java/com/gaaji/townlife/service/applicationservice/townlife/TownLifeRemoveServiceImpl.java
+++ b/src/main/java/com/gaaji/townlife/service/applicationservice/townlife/TownLifeRemoveServiceImpl.java
@@ -20,11 +20,11 @@ public class TownLifeRemoveServiceImpl implements TownLifeRemoveService {
 
     @Override
     @Transactional
-    public void remove(String townLifeId, String authorId) {
+    public void remove(String authId, String townLifeId) {
         TownLife townLife = townLifeRepository.findById(townLifeId)
                 .orElseThrow(() -> new ResourceNotFoundException(ApiErrorCode.TOWN_LIFE_NOT_FOUND));
 
-        validateAuthorizationRemoving(authorId, townLife.getAuthorId());
+        validateAuthorizationRemoving(authId, townLife.getAuthorId());
 
         townLifeCounterRepository.delete(townLife.getTownLifeCounter());
         townLifeRepository.delete(townLife);

--- a/src/main/java/com/gaaji/townlife/service/applicationservice/townlife/TownLifeSubscriptionService.java
+++ b/src/main/java/com/gaaji/townlife/service/applicationservice/townlife/TownLifeSubscriptionService.java
@@ -2,7 +2,7 @@ package com.gaaji.townlife.service.applicationservice.townlife;
 
 public interface TownLifeSubscriptionService {
 
-    void subscribe(String townLifeId, String userId);
-    void unsubscribe(String townLifeId, String userId);
+    void subscribe(String userId, String townLifeId);
+    void unsubscribe(String userId, String townLifeId);
 
 }

--- a/src/main/java/com/gaaji/townlife/service/applicationservice/townlife/TownLifeSubscriptionServiceImpl.java
+++ b/src/main/java/com/gaaji/townlife/service/applicationservice/townlife/TownLifeSubscriptionServiceImpl.java
@@ -19,7 +19,7 @@ public class TownLifeSubscriptionServiceImpl implements TownLifeSubscriptionServ
 
     @Override
     @Transactional
-    public void subscribe(String townLifeId, String userId) {
+    public void subscribe(String userId, String townLifeId) {
 
         TownLife townLife = getTownLifeById(townLifeId);
 
@@ -30,7 +30,7 @@ public class TownLifeSubscriptionServiceImpl implements TownLifeSubscriptionServ
 
     @Override
     @Transactional
-    public void unsubscribe(String townLifeId, String userId) {
+    public void unsubscribe(String userId, String townLifeId) {
 
         TownLife townLife = getTownLifeById(townLifeId);
 

--- a/src/main/java/com/gaaji/townlife/service/controller/townlife/TownLifeImageController.java
+++ b/src/main/java/com/gaaji/townlife/service/controller/townlife/TownLifeImageController.java
@@ -1,0 +1,52 @@
+package com.gaaji.townlife.service.controller.townlife;
+
+import com.gaaji.townlife.service.applicationservice.townlife.TownLifeImageService;
+import com.gaaji.townlife.service.controller.townlife.dto.AttachedImageDto;
+import com.gaaji.townlife.service.controller.townlife.dto.ImageOrderIndexRequestDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/town-lives/{townLifeId}/images")
+@RequiredArgsConstructor
+public class TownLifeImageController {
+
+    private final TownLifeImageService service;
+
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    public List<AttachedImageDto> upload(
+            @RequestHeader(HttpHeaders.AUTHORIZATION) String authId,
+            @PathVariable String townLifeId,
+            @RequestPart("orderIndex") ImageOrderIndexRequestDto dto,
+            @RequestPart("image") MultipartFile[] multipartFiles
+    ) {
+        return service.upload(authId, townLifeId, dto.getOrderIndexes(), multipartFiles);
+    }
+
+    @PutMapping
+    @ResponseStatus(HttpStatus.OK)
+    public List<AttachedImageDto> update(
+            @RequestHeader(HttpHeaders.AUTHORIZATION) String authId,
+            @PathVariable String townLifeId,
+            @RequestPart("orderIndex") ImageOrderIndexRequestDto dto,
+            @RequestPart("image") MultipartFile[] multipartFiles
+    ) {
+        return service.update(authId, townLifeId, dto.getOrderIndexes(), multipartFiles);
+    }
+
+    @DeleteMapping
+    @ResponseStatus(HttpStatus.OK)
+    public List<AttachedImageDto> deleteAll(
+            @RequestHeader(HttpHeaders.AUTHORIZATION) String authId,
+            @PathVariable String townLifeId
+    ) {
+        return service.deleteAll(authId, townLifeId);
+    }
+
+}

--- a/src/main/java/com/gaaji/townlife/service/controller/townlife/TownLifeModifyController.java
+++ b/src/main/java/com/gaaji/townlife/service/controller/townlife/TownLifeModifyController.java
@@ -1,0 +1,28 @@
+package com.gaaji.townlife.service.controller.townlife;
+
+import com.gaaji.townlife.service.applicationservice.townlife.TownLifeModifyService;
+import com.gaaji.townlife.service.controller.townlife.dto.TownLifeDetailDto;
+import com.gaaji.townlife.service.controller.townlife.dto.TownLifeModifyRequestDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/town-lives")
+@RequiredArgsConstructor
+public class TownLifeModifyController {
+
+    private final TownLifeModifyService service;
+
+    @PutMapping("/{townLifeId}")
+    @ResponseStatus(HttpStatus.OK)
+    public TownLifeDetailDto modify(
+            @RequestHeader(HttpHeaders.AUTHORIZATION) String authId,
+            @PathVariable String townLifeId,
+            @RequestBody TownLifeModifyRequestDto dto
+    ) {
+        return service.modify(authId, townLifeId, dto);
+    }
+
+}

--- a/src/main/java/com/gaaji/townlife/service/controller/townlife/TownLifeReactionController.java
+++ b/src/main/java/com/gaaji/townlife/service/controller/townlife/TownLifeReactionController.java
@@ -1,0 +1,37 @@
+package com.gaaji.townlife.service.controller.townlife;
+
+import com.gaaji.townlife.service.applicationservice.townlife.TownLifeReactionService;
+import com.gaaji.townlife.service.controller.townlife.dto.ReactionDoRequestDto;
+import com.gaaji.townlife.service.controller.townlife.dto.ReactionDoResponseDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/town-lives/{townLifeId}/reactions")
+@RequiredArgsConstructor
+public class TownLifeReactionController {
+
+    private final TownLifeReactionService service;
+
+    @PostMapping
+    @ResponseStatus(HttpStatus.OK)
+    public ReactionDoResponseDto doReaction(
+            @RequestHeader(HttpHeaders.AUTHORIZATION) String authId,
+            @PathVariable String townLifeId,
+            @RequestBody ReactionDoRequestDto dto
+    ) {
+        return service.doReaction(authId, townLifeId, dto);
+    }
+
+    @DeleteMapping
+    @ResponseStatus(HttpStatus.OK)
+    public void cancelReaction(
+            @RequestHeader(HttpHeaders.AUTHORIZATION) String authId,
+            @PathVariable String townLifeId
+    ) {
+        service.cancelReaction(authId, townLifeId);
+    }
+    
+}

--- a/src/main/java/com/gaaji/townlife/service/controller/townlife/TownLifeReactionController.java
+++ b/src/main/java/com/gaaji/townlife/service/controller/townlife/TownLifeReactionController.java
@@ -33,5 +33,5 @@ public class TownLifeReactionController {
     ) {
         service.cancelReaction(authId, townLifeId);
     }
-    
+
 }

--- a/src/main/java/com/gaaji/townlife/service/controller/townlife/TownLifeRemoveController.java
+++ b/src/main/java/com/gaaji/townlife/service/controller/townlife/TownLifeRemoveController.java
@@ -1,0 +1,25 @@
+package com.gaaji.townlife.service.controller.townlife;
+
+import com.gaaji.townlife.service.applicationservice.townlife.TownLifeRemoveService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/town-lives")
+@RequiredArgsConstructor
+public class TownLifeRemoveController {
+
+    private final TownLifeRemoveService service;
+
+    @DeleteMapping("/{townLifeId}")
+    @ResponseStatus(HttpStatus.OK)
+    public void remove(
+            @RequestHeader(HttpHeaders.AUTHORIZATION) String authId,
+            @PathVariable String townLifeId
+    ) {
+        service.remove(authId, townLifeId);
+    }
+
+}

--- a/src/main/java/com/gaaji/townlife/service/controller/townlife/TownLifeSubscriptionController.java
+++ b/src/main/java/com/gaaji/townlife/service/controller/townlife/TownLifeSubscriptionController.java
@@ -1,0 +1,34 @@
+package com.gaaji.townlife.service.controller.townlife;
+
+import com.gaaji.townlife.service.applicationservice.townlife.TownLifeSubscriptionService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/town-lives/{townLifeId}/subscriptions")
+@RequiredArgsConstructor
+public class TownLifeSubscriptionController {
+
+    private final TownLifeSubscriptionService service;
+
+    @PostMapping
+    @ResponseStatus(HttpStatus.OK)
+    public void subscribe(
+            @RequestHeader(HttpHeaders.AUTHORIZATION) String authId,
+            @PathVariable String townLifeId
+    ) {
+       service.subscribe(authId, townLifeId);
+    }
+
+    @DeleteMapping
+    @ResponseStatus(HttpStatus.OK)
+    public void unsubscribe(
+            @RequestHeader(HttpHeaders.AUTHORIZATION) String authId,
+            @PathVariable String townLifeId
+    ) {
+        service.unsubscribe(authId, townLifeId);
+    }
+
+}

--- a/src/main/java/com/gaaji/townlife/service/controller/townlife/dto/ImageOrderIndexRequestDto.java
+++ b/src/main/java/com/gaaji/townlife/service/controller/townlife/dto/ImageOrderIndexRequestDto.java
@@ -1,0 +1,14 @@
+package com.gaaji.townlife.service.controller.townlife.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ImageOrderIndexRequestDto {
+
+    private int[] orderIndexes;
+
+}

--- a/src/main/java/com/gaaji/townlife/service/controller/townlife/dto/TownLifeListResponseDto.java
+++ b/src/main/java/com/gaaji/townlife/service/controller/townlife/dto/TownLifeListResponseDto.java
@@ -12,7 +12,7 @@ import java.util.List;
 @AllArgsConstructor
 public class TownLifeListResponseDto {
 
-    private List<TownLifeListDto> content;
     private Boolean hasNext;
+    private List<TownLifeListDto> content;
 
 }

--- a/src/main/java/com/gaaji/townlife/service/controller/townlife/dto/builder/TownLifeResponseBuilder.java
+++ b/src/main/java/com/gaaji/townlife/service/controller/townlife/dto/builder/TownLifeResponseBuilder.java
@@ -21,8 +21,8 @@ public class TownLifeResponseBuilder {
      */
     public static TownLifeListResponseDto townLifeListResponseDto(Slice<TownLife> townLives) {
         return new TownLifeListResponseDto(
-                convertContentFromEntityList(townLives.getContent()),
-                townLives.hasNext()
+                townLives.hasNext(),
+                convertContentFromEntityList(townLives.getContent())
         );
     }
         private static List<TownLifeListDto> convertContentFromEntityList(List<TownLife> townLives) {

--- a/src/main/java/com/gaaji/townlife/service/domain/reaction/Emoji.java
+++ b/src/main/java/com/gaaji/townlife/service/domain/reaction/Emoji.java
@@ -1,10 +1,33 @@
 package com.gaaji.townlife.service.domain.reaction;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.gaaji.townlife.global.exceptions.api.exception.BadRequestException;
+import com.gaaji.townlife.service.domain.townlife.TownLifeType;
+
 public enum Emoji {
-    THUMBS_UP,
-    LIKE,
-    HAPPY,
-    SURPRISED,
-    SAD,
-    ANGRY,
+    THUMBS_UP("thumbs_up"),
+    LIKE("like"),
+    HAPPY("happy"),
+    SURPRISED("surprised"),
+    SAD("sad"),
+    ANGRY("angry");
+    private String value;
+    Emoji(String value) {
+        this.value = value;
+    }
+    @JsonValue
+    public String getValue() {
+        return value;
+    }
+    @JsonCreator
+    public static Emoji from(String value) {
+        String v = value.toLowerCase();
+        for (Emoji emoji : Emoji.values()) {
+            if (emoji.getValue().equals(v)) {
+                return emoji;
+            }
+        }
+        throw new BadRequestException("올바른 Emoji로 요청해주세요. (ex. 'thumbs_up'&'like'&'happy'&'surprised'&'sad'&'angry')");
+    }
 }

--- a/src/main/java/com/gaaji/townlife/service/domain/townlife/TownLife.java
+++ b/src/main/java/com/gaaji/townlife/service/domain/townlife/TownLife.java
@@ -126,10 +126,7 @@ public abstract class TownLife extends BaseEntity {
             throw new ResourceRemoveException(ApiErrorCode.IMAGE_NOT_FOUND);
 
         String[] srcs = this.attachedImages.stream()
-                .map(i -> {
-                    i.associateTownLife(null);
-                    return i.getSrc();
-                })
+                .map(AttachedImage::getSrc)
                 .toArray(String[]::new);
 
         this.attachedImages.clear();

--- a/src/test/java/com/gaaji/townlife/service/applicationservice/townlife/TownLifeImageServiceImplTest.java
+++ b/src/test/java/com/gaaji/townlife/service/applicationservice/townlife/TownLifeImageServiceImplTest.java
@@ -73,7 +73,7 @@ class TownLifeImageServiceImplTest {
 
         int[] orderIndexes = { 1 };
         MockMultipartFile multipartFile = getOneMockImage();
-        List<AttachedImageDto> dto = townLifeImageService.upload(townLifeId, authorId, orderIndexes, multipartFile);
+        List<AttachedImageDto> dto = townLifeImageService.upload(authorId, townLifeId, orderIndexes, multipartFile);
 
         System.out.println(dto);
         Assertions.assertNotNull(dto);
@@ -84,7 +84,7 @@ class TownLifeImageServiceImplTest {
     @Order(200)
     @DisplayName("이미지 파일 1개 정상 삭제")
     void test_delete_one_image_file() {
-        List<AttachedImageDto> dto = townLifeImageService.deleteAll(townLifeId, authorId);
+        List<AttachedImageDto> dto = townLifeImageService.deleteAll(authorId, townLifeId);
 
         Assertions.assertNotNull(dto);
         Assertions.assertEquals(0, dto.size());
@@ -98,7 +98,7 @@ class TownLifeImageServiceImplTest {
 
         int[] orderIndexes = { 1, 2, 3, 4 };
         MultipartFile[] multipartFiles = getFourMockImages();
-        List<AttachedImageDto> dto = townLifeImageService.upload(townLifeId, authorId, orderIndexes, multipartFiles);
+        List<AttachedImageDto> dto = townLifeImageService.upload(authorId, townLifeId, orderIndexes, multipartFiles);
 
         Assertions.assertNotNull(dto);
         Assertions.assertEquals(4, dto.size());
@@ -110,7 +110,7 @@ class TownLifeImageServiceImplTest {
     void test_update_four_image_files() throws Exception {
         int[] orderIndexes = {1, 2, 3, 4};
         MultipartFile[] fourMockImages = getFourMockImages();
-        List<AttachedImageDto> dto = townLifeImageService.update(townLifeId, authorId, orderIndexes, fourMockImages);
+        List<AttachedImageDto> dto = townLifeImageService.update(authorId, townLifeId, orderIndexes, fourMockImages);
 
         Assertions.assertNotNull(dto);
         Assertions.assertEquals(4, dto.size());
@@ -130,7 +130,7 @@ class TownLifeImageServiceImplTest {
     @Order(400)
     @DisplayName("이미지 파일 4개 정상 삭제")
     void test_delete_four_image_files() {
-        List<AttachedImageDto> dto = townLifeImageService.deleteAll(townLifeId, authorId);
+        List<AttachedImageDto> dto = townLifeImageService.deleteAll(authorId, townLifeId);
 
         Assertions.assertNotNull(dto);
         Assertions.assertEquals(0, dto.size());
@@ -144,7 +144,7 @@ class TownLifeImageServiceImplTest {
         MockMultipartFile multipartFile = getOneMockImageWrongContentType();
 
         ResourceSaveException ex = Assertions.assertThrows(ResourceSaveException.class,
-                () -> townLifeImageService.upload(townLifeId, authorId, orderIndexes, multipartFile));
+                () -> townLifeImageService.upload(authorId, townLifeId, orderIndexes, multipartFile));
         Assertions.assertEquals(ApiErrorCode.IMAGE_CONTENT_TYPE_ERROR.getErrorCode(), ex.getErrorCode());
     }
 
@@ -156,7 +156,7 @@ class TownLifeImageServiceImplTest {
         MultipartFile[] multipartFiles = getFourMockImages();
 
         ResourceSaveException ex = Assertions.assertThrows(ResourceSaveException.class,
-                () -> townLifeImageService.upload(townLifeId, authorId, orderIndexes, multipartFiles));
+                () -> townLifeImageService.upload(authorId, townLifeId, orderIndexes, multipartFiles));
         Assertions.assertEquals(ApiErrorCode.IMAGE_REQUIRE_VALUE_BAD_REQUEST.getErrorCode(), ex.getErrorCode());
     }
 
@@ -169,7 +169,7 @@ class TownLifeImageServiceImplTest {
 
         String authId = "wrong_author";
         ResourceAuthorizationException ex = Assertions.assertThrows(ResourceAuthorizationException.class,
-                () -> townLifeImageService.upload(townLifeId, authId, orderIndexes, multipartFile));
+                () -> townLifeImageService.upload(authId, townLifeId, orderIndexes, multipartFile));
         Assertions.assertEquals(ApiErrorCode.AUTHORIZATION_MODIFY_ERROR.getErrorCode(), ex.getErrorCode());
     }
 
@@ -180,7 +180,7 @@ class TownLifeImageServiceImplTest {
         int[] orderIndexes = {1,2,3,4};
 
         ResourceSaveException ex = Assertions.assertThrows(ResourceSaveException.class,
-                () -> townLifeImageService.upload(townLifeId, authorId, orderIndexes, (MultipartFile) null));
+                () -> townLifeImageService.upload(authorId, townLifeId, orderIndexes, (MultipartFile) null));
         Assertions.assertEquals(ApiErrorCode.IMAGE_REQUIRE_VALUE_BAD_REQUEST.getErrorCode(), ex.getErrorCode());
     }
 
@@ -191,7 +191,7 @@ class TownLifeImageServiceImplTest {
         init_post_town_life();
 
         ResourceRemoveException ex = Assertions.assertThrows(ResourceRemoveException.class,
-                () -> townLifeImageService.deleteAll(townLifeId, authorId));
+                () -> townLifeImageService.deleteAll(authorId, townLifeId));
         Assertions.assertEquals(ApiErrorCode.IMAGE_NOT_FOUND.getErrorCode(), ex.getErrorCode());
     }
 

--- a/src/test/java/com/gaaji/townlife/service/applicationservice/townlife/TownLifeModifyServiceImplTest.java
+++ b/src/test/java/com/gaaji/townlife/service/applicationservice/townlife/TownLifeModifyServiceImplTest.java
@@ -55,7 +55,7 @@ class TownLifeModifyServiceImplTest {
         // 테스트 구독 유저 생성
         for (int i = 1; i <= 5; i++) {
             String userId = "user_"+i;
-            townLifeSubscriptionService.subscribe(townLifeId, userId);
+            townLifeSubscriptionService.subscribe(userId, townLifeId);
         }
 
         TownLifeModifyRequestDto dto = new TownLifeModifyRequestDto("수정 게시글", "수정 게시글 내용입니다.", "");

--- a/src/test/java/com/gaaji/townlife/service/applicationservice/townlife/TownLifeSubscriptionServiceImplTest.java
+++ b/src/test/java/com/gaaji/townlife/service/applicationservice/townlife/TownLifeSubscriptionServiceImplTest.java
@@ -44,17 +44,17 @@ class TownLifeSubscriptionServiceImplTest {
     void test_about_town_life_subscribe() {
         init_town_life();
 
-        townLifeSubscriptionService.subscribe(postTownLifeId, userId);
+        townLifeSubscriptionService.subscribe(userId, postTownLifeId);
 
-        Assertions.assertThrows(ResourceAlreadyExistException.class, () -> townLifeSubscriptionService.subscribe(postTownLifeId, userId));
+        Assertions.assertThrows(ResourceAlreadyExistException.class, () -> townLifeSubscriptionService.subscribe(userId, postTownLifeId));
     }
 
     @Test
     @Order(200)
     @DisplayName("동네생활 게시글 알림 요청 취소")
     void test_about_town_life_unsubscribe() {
-        townLifeSubscriptionService.unsubscribe(postTownLifeId, userId);
+        townLifeSubscriptionService.unsubscribe(userId, postTownLifeId);
 
-        Assertions.assertThrows(ResourceRemoveException.class, () -> townLifeSubscriptionService.unsubscribe(postTownLifeId, userId));
+        Assertions.assertThrows(ResourceRemoveException.class, () -> townLifeSubscriptionService.unsubscribe(userId, postTownLifeId));
     }
 }


### PR DESCRIPTION
# [GM-311] townlife controller 구현
## Description
> TownLife 도메인의 Controller를 구현하여 api endpoint를 추가하였다.
> Controller는 ApplicationService와 1:1 매핑되도록 하여 Save, Find, Modify, Remove, Reaction, Subscription, Image로 구성된다.

## PR Type
- [ ] Hotfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor (code, package, etc.)
- [ ] Build (gradle, spring, etc) 
- [ ] Documentation content changes (api docs, etc.)
- [ ] Infra (cloud, security, etc.)
- [ ] Other... Please describe :

## Related Issues
- GM-312
- GM-313
- GM-314
- GM-315
- GM-321
- GM-322
- GM-323

## Think About..  
> 

## Conclusion  
> 
