### PR TITLE
[GM-325] refactor 작성자에게만 반응 알림 전송

### DIFF
--- a/src/main/java/com/gaaji/townlife/service/applicationservice/townlife/TownLifeReactionServiceImpl.java
+++ b/src/main/java/com/gaaji/townlife/service/applicationservice/townlife/TownLifeReactionServiceImpl.java
@@ -44,7 +44,7 @@ public class TownLifeReactionServiceImpl implements TownLifeReactionService {
 
         eventPublisher.publishEvent(new TownLifeReactionAddedEvent(
                 TownLifeReactionService.class,
-                TownLifeEventBody.of(responseDto.getUserId(), townLife.getSubscriptions())
+                TownLifeEventBody.of(responseDto.getUserId(), townLife.getAuthorAmongSubscription())
         ));
 
         return responseDto;

--- a/src/main/java/com/gaaji/townlife/service/applicationservice/townlife/TownLifeSaveServiceImpl.java
+++ b/src/main/java/com/gaaji/townlife/service/applicationservice/townlife/TownLifeSaveServiceImpl.java
@@ -12,6 +12,7 @@ import com.gaaji.townlife.service.domain.townlife.*;
 import com.gaaji.townlife.service.repository.CategoryRepository;
 import com.gaaji.townlife.service.repository.TownLifeCounterRepository;
 import com.gaaji.townlife.service.repository.TownLifeRepository;
+import com.gaaji.townlife.service.repository.TownLifeSubscriptionRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -25,6 +26,7 @@ public class TownLifeSaveServiceImpl implements TownLifeSaveService {
     private final CategoryRepository categoryRepository;
     private final TownLifeRepository townLifeRepository;
     private final TownLifeCounterRepository townLifeCounterRepository;
+    private final TownLifeSubscriptionRepository townLifeSubscriptionRepository;
 
     @Override
     @Transactional
@@ -53,9 +55,9 @@ public class TownLifeSaveServiceImpl implements TownLifeSaveService {
             T townLife = townLifeRepository.save(
                     clazz.getConstructor(String.class, String.class, String.class, String.class, String.class)
                             .newInstance(dto.getAuthorId(), dto.getTownId(), dto.getTitle(), dto.getText(), dto.getLocation()));
-
             townLife.associateCategory(category);
-            townLife.addSubscription(TownLifeSubscription.of(dto.getAuthorId()));
+
+            saveSubscription(townLife);
             saveCounter(townLife);
 
             return townLife;
@@ -63,6 +65,11 @@ public class TownLifeSaveServiceImpl implements TownLifeSaveService {
         } catch (Exception e) {
             throw new ResourceSaveException(ApiErrorCode.TOWN_LIFE_SAVE_ERROR, e);
         }
+    }
+
+    private <T extends TownLife> void saveSubscription(T townLife) {
+        TownLifeSubscription subscription = townLifeSubscriptionRepository.save(TownLifeSubscription.of(townLife.getAuthorId()));
+        townLife.addSubscription(subscription);
     }
 
     private <T extends TownLife> void saveCounter(T townLife) {

--- a/src/main/java/com/gaaji/townlife/service/domain/townlife/TownLife.java
+++ b/src/main/java/com/gaaji/townlife/service/domain/townlife/TownLife.java
@@ -17,6 +17,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 @Entity
 @Getter
@@ -136,5 +137,11 @@ public abstract class TownLife extends BaseEntity {
 
     public void addComment(ParentComment parentComment) {
         this.comments.add(parentComment);
+    }
+
+    public List<TownLifeSubscription> getAuthorAmongSubscription() {
+        return this.subscriptions.stream()
+                .filter(subscriptions -> Objects.equals(this.authorId, subscriptions.getUserId()))
+                .collect(Collectors.toList());
     }
 }

--- a/src/main/java/com/gaaji/townlife/service/event/ApplicationEventHandler.java
+++ b/src/main/java/com/gaaji/townlife/service/event/ApplicationEventHandler.java
@@ -75,7 +75,7 @@ public class ApplicationEventHandler {
 
         kafkaProducer.produceEvent(new NotificationEvent(
                 event.getSource(),
-                NotificationEventBody.of("관심 가진 동네생활에 누군가 반응을 했어요!", subscribedUserIds)
+                NotificationEventBody.of("다른 사용자가 회원님의 게시글에 반응했어요!", subscribedUserIds)
         ));
     }
 
@@ -85,6 +85,5 @@ public class ApplicationEventHandler {
                 .filter(subscribedUserId -> !Objects.equals(event.getBody().getIssuedUserId(), subscribedUserId))
                 .collect(Collectors.toList());
     }
-
 
 }


### PR DESCRIPTION
# [GM-325] refactor 작성자에게만 반응 알림 전송
## Description
> 어느 회원이 게시글에 반응(Reaction)하게 되면, 기존에는 모든 알림구독 유저에게 알림을 요청하지만, 
> 비즈니스 상, 작성자에게만 알림을 요청하는 것이 좋아보이기에
> 반응 시 작성자에게만 알림을 요청하는 것으로 변경하였다.

## PR Type
- [ ] Hotfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor (code, package, etc.)
- [ ] Build (gradle, spring, etc) 
- [ ] Documentation content changes (api docs, etc.)
- [ ] Infra (cloud, security, etc.)
- [ ] Other... Please describe :

## Related Issues
- 

## Issues
### TownLife 엔티티의 Subscription에서 Author에 해당하는 Subscription 가져오기
기존 이벤트 발행 로직이 TownLife의 Subscription 리스트를 이벤트 핸들러에게 전달하도록 한다.  
따라서 기존 로직을 수정하지 않고 작성자에 해당하는 Subscription 엔티티만 전달하기 위해 아래와 같이 메소드를 만들었다..

```java
// TownLife.java

    public List<TownLifeSubscription> getAuthorAmongSubscription() {
        return this.subscriptions.stream()
                .filter(subscriptions -> Objects.equals(this.authorId, subscriptions.getUserId()))
                .collect(Collectors.toList());
    }
```

### 반응 시 발생하는 이벤트
```java
// TownLifeReactionServiceImpl.java

    public ReactionDoResponseDto doReaction(String userId, String townLifeId, ReactionDoRequestDto dto) {
         (중략)
         eventPublisher.publishEvent(new TownLifeReactionAddedEvent(
                TownLifeReactionService.class,
                TownLifeEventBody.of(responseDto.getUserId(), townLife.getAuthorAmongSubscription())
        ));
        return responseDto;
    }
```

### 이벤트 소비하여 Kafka를 통해 Noti 서버로 전달
```java
// ApplicationEventHandler.java

    @EventListener
    public void handleTownLifeReactionAdded(TownLifeReactionAddedEvent event) {
        List<String> subscribedUserIds = getSubscribedUserIds(event);

        kafkaProducer.produceEvent(new NotificationEvent(
                event.getSource(),
                NotificationEventBody.of("다른 사용자가 회원님의 게시글에 반응했어요!", subscribedUserIds)
        ));
    }
```

## Test
![image](https://user-images.githubusercontent.com/42243302/221127110-ee2f9c45-e31c-47bc-a690-d0bad9041c60.png)

사진과 같이 subscriber는 더 존재하지만, 다른 사용자가 게시글 반응 시 작성자(saver01)에게만 알림가는 것을 볼 수 있다.

> 메시지는 변경하였다. -> `"다른 사용자가 회원님의 게시글에 반응했어요!"`

## Think About..  
> 

## Conclusion  
> 
