### PR TITLE
[GM-330] Hotfix 버그 발견

### DIFF
--- a/src/main/java/com/gaaji/townlife/global/utils/ulid/ULIDGenerator.java
+++ b/src/main/java/com/gaaji/townlife/global/utils/ulid/ULIDGenerator.java
@@ -7,17 +7,18 @@ import org.hibernate.id.IdentifierGenerator;
 
 import java.io.Serializable;
 import java.time.LocalDateTime;
-import java.time.ZoneOffset;
+import java.time.ZoneId;
 
 public class ULIDGenerator implements IdentifierGenerator {
-    private final ULID ulid = new ULID();
+    private static final ULID ulid = new ULID();
 
     @Override
     public Serializable generate(SharedSessionContractImplementor session, Object object) throws HibernateException {
         return ulid.nextULID();
     }
 
-    public static String newULIDByRequestTime(LocalDateTime requestTime) {
-        return new ULID().nextULID(requestTime.toInstant(ZoneOffset.UTC).toEpochMilli());
+    public static String offsetId(LocalDateTime requestTime) {
+        long timestamp = requestTime.atZone(ZoneId.systemDefault()).toInstant().toEpochMilli();
+        return ulid.nextULID(timestamp);
     }
 }

--- a/src/main/java/com/gaaji/townlife/service/applicationservice/category/CategorySubscriptionServiceImpl.java
+++ b/src/main/java/com/gaaji/townlife/service/applicationservice/category/CategorySubscriptionServiceImpl.java
@@ -22,7 +22,8 @@ public class CategorySubscriptionServiceImpl implements CategorySubscriptionServ
     public void subscribe(String userId, String categoryId) {
         Category category = getCategoryById(categoryId);
 
-        category.removeUnsubscriptionByUserId(userId);
+        CategoryUnsubscription unsubscription = category.removeUnsubscriptionByUserId(userId);
+        categoryUnsubscriptionRepository.delete(unsubscription);
     }
 
     @Override

--- a/src/main/java/com/gaaji/townlife/service/applicationservice/townlife/TownLifeFindServiceImpl.java
+++ b/src/main/java/com/gaaji/townlife/service/applicationservice/townlife/TownLifeFindServiceImpl.java
@@ -45,7 +45,7 @@ public class TownLifeFindServiceImpl implements TownLifeFindService {
     @Transactional
     public TownLifeListResponseDto findListByTownId(String userId, String townId, LocalDateTime requestTime, int page, int size) {
 
-        String offsetId = ULIDGenerator.newULIDByRequestTime(requestTime);
+        String offsetId = ULIDGenerator.offsetId(requestTime);
         Slice<TownLife> townLives = entityService.findListByTownIdAndIdLessThan(userId, townId, offsetId, page, size);
 
         return TownLifeResponseBuilder.townLifeListResponseDto(townLives);
@@ -55,7 +55,7 @@ public class TownLifeFindServiceImpl implements TownLifeFindService {
     @Transactional
     public TownLifeListResponseDto findListByUserId(String userId, LocalDateTime requestTime, int page, int size) {
 
-        String offsetId = ULIDGenerator.newULIDByRequestTime(requestTime);
+        String offsetId = ULIDGenerator.offsetId(requestTime);
         Slice<TownLife> townLives = entityService.findListByUserIdAndIdLessThan(userId, offsetId, page, size);
 
         return TownLifeResponseBuilder.townLifeListResponseDto(townLives);

--- a/src/main/java/com/gaaji/townlife/service/applicationservice/townlife/TownLifeSubscriptionServiceImpl.java
+++ b/src/main/java/com/gaaji/townlife/service/applicationservice/townlife/TownLifeSubscriptionServiceImpl.java
@@ -24,7 +24,6 @@ public class TownLifeSubscriptionServiceImpl implements TownLifeSubscriptionServ
         TownLife townLife = getTownLifeById(townLifeId);
 
         TownLifeSubscription subscription = townLifeSubscriptionRepository.save(TownLifeSubscription.of(userId));
-
         townLife.addSubscription(subscription);
     }
 
@@ -34,7 +33,8 @@ public class TownLifeSubscriptionServiceImpl implements TownLifeSubscriptionServ
 
         TownLife townLife = getTownLifeById(townLifeId);
 
-        townLife.removeSubscriptionByUserId(userId);
+        TownLifeSubscription subscription = townLife.removeSubscriptionByUserId(userId);
+        townLifeSubscriptionRepository.delete(subscription);
     }
 
     private TownLife getTownLifeById(String id) {

--- a/src/main/java/com/gaaji/townlife/service/domain/category/Category.java
+++ b/src/main/java/com/gaaji/townlife/service/domain/category/Category.java
@@ -86,7 +86,7 @@ public class Category {
         }
     }
 
-    public void removeUnsubscriptionByUserId(String userId) {
+    public CategoryUnsubscription removeUnsubscriptionByUserId(String userId) {
         Optional<CategoryUnsubscription> unsubscriptionOptional = this.unsubscriptions.stream()
                 .filter(us -> Objects.equals(us.getUserId(), userId))
                 .findFirst();
@@ -96,6 +96,8 @@ public class Category {
             CategoryUnsubscription unsubscription = unsubscriptionOptional.get();
             this.unsubscriptions.remove(unsubscription);
             unsubscription.associateCategory(null);
+
+            return unsubscription;
 
         } else {
             throw new ResourceRemoveException(ApiErrorCode.CATEGORY_UNSUBSCRIPTION_NOT_FOUND);

--- a/src/main/java/com/gaaji/townlife/service/domain/townlife/TownLife.java
+++ b/src/main/java/com/gaaji/townlife/service/domain/townlife/TownLife.java
@@ -84,7 +84,7 @@ public abstract class TownLife extends BaseEntity {
         }
     }
 
-    public void removeSubscriptionByUserId(String userId) {
+    public TownLifeSubscription removeSubscriptionByUserId(String userId) {
         Optional<TownLifeSubscription> subscriptionOpt = this.subscriptions.stream()
                 .filter(s -> Objects.equals(s.getUserId(), userId))
                 .findFirst();
@@ -94,6 +94,8 @@ public abstract class TownLife extends BaseEntity {
             TownLifeSubscription subscription = subscriptionOpt.get();
             this.subscriptions.remove(subscription);
             subscription.associateTownLife(null);
+
+            return subscription;
 
         } else {
             throw new ResourceRemoveException(ApiErrorCode.TOWN_LIFE_SUBSCRIPTION_NOT_FOUND);


### PR DESCRIPTION
# [GM-330] Hotfix 버그 발견
## Description
> 카테고리 비구독 데이터 미삭제 버그 및 메인페이지 등 request time을 이용한 offsetId 미적용 버그가 발견되어 해결한 PR이다.

## PR Type
- [x] Hotfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor (code, package, etc.)
- [ ] Build (gradle, spring, etc) 
- [ ] Documentation content changes (api docs, etc.)
- [ ] Infra (cloud, security, etc.)
- [ ] Other... Please describe :

## Related Issues
- GM-331
- GM-332

## Issues
### 카테고리 비구독 데이터 미삭제
카테고리 구독요청 시 비구독 데이터가 기존 코드에서 삭제가 안돼서,
1. 구독 취소 요청
2. 메인페이지 조회
3. 구독 요청
4. 메인페이지 조회  


시 읽어올 데이터가 없다고 하는 버그가 발견되었다.  
따라서 다음과 같이 수정하였다.

```java
    @Override
    @Transactional
    public void subscribe(String userId, String categoryId) {
        Category category = getCategoryById(categoryId);

        CategoryUnsubscription unsubscription = category.removeUnsubscriptionByUserId(userId);
        categoryUnsubscriptionRepository.delete(unsubscription);
    }
```

### OffsetId 미적용 버그
기존 코드에서는 `requestTime`을 이용하여 timestamp를 가져올 때,  `ZoneOffset.UTC`로 설정되어 있었는데,  
그래서 그런지 요청하는 날짜를 게시글 생성 시간보다 이전의 시간으로 요청해도 응답되는 문제가 발생하였다.  

따라서 아래 코드와 같이 `systemDefault()`를 통해 해결하였다.

```java
    public static String offsetId(LocalDateTime requestTime) {
        long timestamp = requestTime.atZone(ZoneId.systemDefault()).toInstant().toEpochMilli();
        return ulid.nextULID(timestamp);
    }
```

## Test
###

## Related Files
- `file`

## Think About..  
> 

## Conclusion  
> 
