### PR TITLE
[GM-301] townlife connect auth service

### DIFF
--- a/src/main/java/com/gaaji/townlife/service/adapter/gaaji/AuthServiceClient.java
+++ b/src/main/java/com/gaaji/townlife/service/adapter/gaaji/AuthServiceClient.java
@@ -1,0 +1,14 @@
+package com.gaaji.townlife.service.adapter.gaaji;
+
+import com.gaaji.townlife.service.adapter.gaaji.dto.AuthProfileDto;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+
+@FeignClient(value = "auth-service", primary = false)
+public interface AuthServiceClient {
+
+    @GetMapping("/auth/{authId}")
+    AuthProfileDto getAuthProfile(@PathVariable String authId);
+
+}

--- a/src/main/java/com/gaaji/townlife/service/adapter/gaaji/TownServiceClient.java
+++ b/src/main/java/com/gaaji/townlife/service/adapter/gaaji/TownServiceClient.java
@@ -1,0 +1,14 @@
+package com.gaaji.townlife.service.adapter.gaaji;
+
+import com.gaaji.townlife.service.adapter.gaaji.dto.TownAddressDto;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+
+@FeignClient(value = "town-service", primary = false)
+public interface TownServiceClient {
+
+    @GetMapping("/town/{townId}")
+    TownAddressDto getTownAddress(@PathVariable("townId") String townId);
+
+}

--- a/src/main/java/com/gaaji/townlife/service/adapter/gaaji/dto/AuthProfileDto.java
+++ b/src/main/java/com/gaaji/townlife/service/adapter/gaaji/dto/AuthProfileDto.java
@@ -1,0 +1,17 @@
+package com.gaaji.townlife.service.adapter.gaaji.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class AuthProfileDto {
+
+    private String authId;
+    private String nickname;
+    private String pictureUrl;
+    private double mannerTemperature;
+
+}

--- a/src/main/java/com/gaaji/townlife/service/adapter/gaaji/dto/TownAddressDto.java
+++ b/src/main/java/com/gaaji/townlife/service/adapter/gaaji/dto/TownAddressDto.java
@@ -1,0 +1,14 @@
+package com.gaaji.townlife.service.adapter.gaaji.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class TownAddressDto {
+
+    private String address;
+
+}

--- a/src/main/java/com/gaaji/townlife/service/applicationservice/townlife/TownLifeFindServiceImpl.java
+++ b/src/main/java/com/gaaji/townlife/service/applicationservice/townlife/TownLifeFindServiceImpl.java
@@ -1,6 +1,8 @@
 package com.gaaji.townlife.service.applicationservice.townlife;
 
 import com.gaaji.townlife.global.utils.ulid.ULIDGenerator;
+import com.gaaji.townlife.service.adapter.gaaji.AuthServiceClient;
+import com.gaaji.townlife.service.adapter.gaaji.dto.AuthProfileDto;
 import com.gaaji.townlife.service.controller.townlife.dto.TownLifeDetailDto;
 import com.gaaji.townlife.service.controller.townlife.dto.TownLifeListResponseDto;
 import com.gaaji.townlife.service.controller.townlife.dto.builder.TownLifeResponseBuilder;
@@ -21,24 +23,25 @@ public class TownLifeFindServiceImpl implements TownLifeFindService {
 
     private final TownLifeFindEntityService entityService;
     private final TownLifeFindCountService countService;
+    private final AuthServiceClient authServiceClient;
 
     @Override
     @Transactional
     public TownLifeDetailDto findById(String townLifeId) {
         TownLife townLife = entityService.findById(townLifeId);
-        //TODO get auth profile
+        AuthProfileDto authProfileDto = authServiceClient.getAuthProfile(townLife.getAuthorId());
 
-        return TownLifeResponseBuilder.townLifeDetailDto(townLife);
+        return TownLifeResponseBuilder.townLifeDetailDto(townLife, authProfileDto);
     }
 
     @Override
     @Transactional
     public TownLifeDetailDto visit(String townLifeId) {
         TownLife townLife = entityService.findById(townLifeId);
-        //TODO get auth profile
         TownLifeCounter counter = countService.increaseViewCount(townLife.getTownLifeCounter().getId());
+        AuthProfileDto authProfileDto = authServiceClient.getAuthProfile(townLife.getAuthorId());
 
-        return TownLifeResponseBuilder.townLifeDetailDto(townLife, counter);
+        return TownLifeResponseBuilder.townLifeDetailDto(townLife, authProfileDto, counter);
     }
 
     @Override

--- a/src/main/java/com/gaaji/townlife/service/applicationservice/townlife/TownLifeModifyServiceImpl.java
+++ b/src/main/java/com/gaaji/townlife/service/applicationservice/townlife/TownLifeModifyServiceImpl.java
@@ -2,6 +2,8 @@ package com.gaaji.townlife.service.applicationservice.townlife;
 
 import com.gaaji.townlife.global.exceptions.api.ApiErrorCode;
 import com.gaaji.townlife.global.exceptions.api.exception.ResourceNotFoundException;
+import com.gaaji.townlife.service.adapter.gaaji.AuthServiceClient;
+import com.gaaji.townlife.service.adapter.gaaji.dto.AuthProfileDto;
 import com.gaaji.townlife.service.controller.townlife.dto.TownLifeDetailDto;
 import com.gaaji.townlife.service.controller.townlife.dto.TownLifeModifyRequestDto;
 import com.gaaji.townlife.service.controller.townlife.dto.builder.TownLifeResponseBuilder;
@@ -24,6 +26,7 @@ public class TownLifeModifyServiceImpl implements TownLifeModifyService {
 
     private final TownLifeRepository townLifeRepository;
     private final ApplicationEventPublisher eventPublisher;
+    private final AuthServiceClient authServiceClient;
 
     @Override
     @Transactional
@@ -34,13 +37,14 @@ public class TownLifeModifyServiceImpl implements TownLifeModifyService {
         validateAuthorizationModifying(authId, townLife.getAuthorId());
 
         townLife.updateContent(dto.getTitle(), dto.getText(), dto.getLocation());
+        AuthProfileDto authProfileDto = authServiceClient.getAuthProfile(townLife.getAuthorId());
 
         eventPublisher.publishEvent(new TownLifeUpdatedEvent(
                 TownLifeModifyService.class,
                 TownLifeEventBody.of(townLife.getAuthorId(), townLife.getSubscriptions())
         ));
 
-        return TownLifeResponseBuilder.townLifeDetailDto(townLife, townLife.getTownLifeCounter());
+        return TownLifeResponseBuilder.townLifeDetailDto(townLife, authProfileDto, townLife.getTownLifeCounter());
     }
 
 }

--- a/src/main/java/com/gaaji/townlife/service/controller/townlife/dto/TownLifeDetailDto.java
+++ b/src/main/java/com/gaaji/townlife/service/controller/townlife/dto/TownLifeDetailDto.java
@@ -12,8 +12,13 @@ import java.util.List;
 @Builder
 public class TownLifeDetailDto {
     private String id;
-    private String authorId;
     private TownLifeDetailCategoryDto category;
+    private String authorId;
+    private String authorNickName;
+    private String authorProfilePictureUrl;
+    private double authorMannerTemperature;
+    private String townId;
+    private String townAddress;
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
     private Boolean isUpdated;

--- a/src/main/java/com/gaaji/townlife/service/controller/townlife/dto/builder/TownLifeResponseBuilder.java
+++ b/src/main/java/com/gaaji/townlife/service/controller/townlife/dto/builder/TownLifeResponseBuilder.java
@@ -1,5 +1,6 @@
 package com.gaaji.townlife.service.controller.townlife.dto.builder;
 
+import com.gaaji.townlife.service.adapter.gaaji.dto.AuthProfileDto;
 import com.gaaji.townlife.service.controller.townlife.dto.*;
 import com.gaaji.townlife.service.domain.category.Category;
 import com.gaaji.townlife.service.domain.reaction.Emoji;
@@ -48,33 +49,33 @@ public class TownLifeResponseBuilder {
     /*
     TownLifeDetailDto
      */
-    public static TownLifeDetailDto townLifeDetailDto(TownLife entity) {
+    public static TownLifeDetailDto townLifeDetailDto(TownLife entity, AuthProfileDto authProfileDto) {
         TownLifeDetailDto response = null;
         switch (entity.getCategory().getTownLifeType()) {
             case POST:
-                response = postTownLifeDetailDto(entity, entity.getViewCount(), entity.getReactionCount(), entity.getCommentCount(), entity.getInterestCount());
+                response = postTownLifeDetailDto(entity, authProfileDto, entity.getViewCount(), entity.getReactionCount(), entity.getCommentCount(), entity.getInterestCount());
                 break;
             case QUESTION:
-                response = questionTownLifeDetailDto(entity, entity.getViewCount(), entity.getReactionCount(), entity.getCommentCount(), entity.getInterestCount());
+                response = questionTownLifeDetailDto(entity, authProfileDto, entity.getViewCount(), entity.getReactionCount(), entity.getCommentCount(), entity.getInterestCount());
                 break;
         }
         return response;
     }
 
-    public static TownLifeDetailDto townLifeDetailDto(TownLife entity, TownLifeCounter counter) {
+    public static TownLifeDetailDto townLifeDetailDto(TownLife entity, AuthProfileDto authProfileDto, TownLifeCounter counter) {
         TownLifeDetailDto response = null;
         switch (entity.getCategory().getTownLifeType()) {
             case POST:
-                response = postTownLifeDetailDto(entity, counter.getViewCount(), counter.getReactionCount(), counter.getCommentCount(), counter.getInterestCount());
+                response = postTownLifeDetailDto(entity, authProfileDto, counter.getViewCount(), counter.getReactionCount(), counter.getCommentCount(), counter.getInterestCount());
                 break;
             case QUESTION:
-                response = questionTownLifeDetailDto(entity, counter.getViewCount(), counter.getReactionCount(), counter.getCommentCount(), counter.getInterestCount());
+                response = questionTownLifeDetailDto(entity, authProfileDto, counter.getViewCount(), counter.getReactionCount(), counter.getCommentCount(), counter.getInterestCount());
                 break;
         }
         return response;
     }
 
-        private static TownLifeDetailDto.TownLifeDetailDtoBuilder commonTownLifeDetailDto(TownLife entity, int viewCount, int reactionCount, int commentCount, int interestCount) {
+        private static TownLifeDetailDto.TownLifeDetailDtoBuilder commonTownLifeDetailDto(TownLife entity, AuthProfileDto authProfileDto, int viewCount, int reactionCount, int commentCount, int interestCount) {
             /*
             TownLife 조회 로직에 따라 ViewCount가 증가하면 entity의 updatedAt이 변경되는 것을 확인하였다...
             다만, 변경된 시간이 밀리세컨드 단위임을 확인하였으므로
@@ -87,10 +88,15 @@ public class TownLifeResponseBuilder {
 
             return TownLifeDetailDto.builder()
                     .id(entity.getId())
-                    .authorId(entity.getAuthorId())
                     .category(
                             townLifeDetailCategoryDto(entity.getCategory())
                     )
+                    .authorId(authProfileDto.getAuthId())
+                    .authorNickName(authProfileDto.getNickname())
+                    .authorProfilePictureUrl(authProfileDto.getPictureUrl())
+                    .authorMannerTemperature(authProfileDto.getMannerTemperature())
+                    .townId(entity.getTownId())
+                    .townAddress(entity.getTownAddress())
                     .createdAt(createdAt)
                     .updatedAt(updatedAt)
                     .isUpdated(isUpdated)
@@ -106,8 +112,8 @@ public class TownLifeResponseBuilder {
                     );
         }
 
-        private static TownLifeDetailDto postTownLifeDetailDto(TownLife entity, int viewCount, int reactionCount, int commentCount, int interestCount) {
-            return commonTownLifeDetailDto(entity, viewCount, reactionCount, commentCount, interestCount)
+        private static TownLifeDetailDto postTownLifeDetailDto(TownLife entity, AuthProfileDto authProfileDto, int viewCount, int reactionCount, int commentCount, int interestCount) {
+            return commonTownLifeDetailDto(entity, authProfileDto, viewCount, reactionCount, commentCount, interestCount)
                     .postReactionDtos(
                             postReactionDtoList((PostTownLife) entity)
                     )
@@ -126,8 +132,8 @@ public class TownLifeResponseBuilder {
             }
 
 
-        private static TownLifeDetailDto questionTownLifeDetailDto(TownLife entity, int viewCount, int reactionCount, int commentCount, int interestCount) {
-            return commonTownLifeDetailDto(entity, viewCount, reactionCount, commentCount, interestCount)
+        private static TownLifeDetailDto questionTownLifeDetailDto(TownLife entity, AuthProfileDto authProfileDto, int viewCount, int reactionCount, int commentCount, int interestCount) {
+            return commonTownLifeDetailDto(entity, authProfileDto, viewCount, reactionCount, commentCount, interestCount)
                     .postReactionDtos(null)
                     .questionReactionDtos(
                             questionReactionDtoList((QuestionTownLife) entity)

--- a/src/main/java/com/gaaji/townlife/service/domain/townlife/PostTownLife.java
+++ b/src/main/java/com/gaaji/townlife/service/domain/townlife/PostTownLife.java
@@ -2,10 +2,12 @@ package com.gaaji.townlife.service.domain.townlife;
 
 import com.gaaji.townlife.global.exceptions.api.ApiErrorCode;
 import com.gaaji.townlife.global.exceptions.api.exception.ResourceRemoveException;
-import com.gaaji.townlife.service.controller.townlife.dto.TownLifeSaveRequestDto;
 import com.gaaji.townlife.service.domain.reaction.PostReaction;
 import com.gaaji.townlife.service.domain.reaction.Reaction;
-import lombok.*;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 import org.hibernate.annotations.OnDelete;
 import org.hibernate.annotations.OnDeleteAction;
 
@@ -29,16 +31,8 @@ public class PostTownLife extends TownLife {
     @OneToMany(mappedBy = "postTownLife", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<PostReaction> reactions = new ArrayList<>();
 
-    public PostTownLife(String authorId, String townId, String title, String text, String location) {
-        super(authorId, townId, title, text, location);
-    }
-
-    public static PostTownLife create(TownLifeSaveRequestDto dto) {
-        return new PostTownLife(
-                dto.getAuthorId(),
-                dto.getTownId(),
-                dto.getTitle(), dto.getText(), dto.getLocation()
-        );
+    public PostTownLife(String authorId, String townId, String townAddress, String title, String text, String location) {
+        super(authorId, townId, townAddress, title, text, location);
     }
 
     @Override

--- a/src/main/java/com/gaaji/townlife/service/domain/townlife/QuestionTownLife.java
+++ b/src/main/java/com/gaaji/townlife/service/domain/townlife/QuestionTownLife.java
@@ -2,10 +2,12 @@ package com.gaaji.townlife.service.domain.townlife;
 
 import com.gaaji.townlife.global.exceptions.api.ApiErrorCode;
 import com.gaaji.townlife.global.exceptions.api.exception.ResourceRemoveException;
-import com.gaaji.townlife.service.controller.townlife.dto.TownLifeSaveRequestDto;
 import com.gaaji.townlife.service.domain.reaction.QuestionReaction;
 import com.gaaji.townlife.service.domain.reaction.Reaction;
-import lombok.*;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 import org.hibernate.annotations.OnDelete;
 import org.hibernate.annotations.OnDeleteAction;
 
@@ -28,16 +30,8 @@ public class QuestionTownLife extends TownLife {
     @OneToMany(mappedBy = "questionTownLife", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<QuestionReaction> reactions = new ArrayList<>();
 
-    public QuestionTownLife(String authorId, String townId, String title, String text, String location) {
-        super(authorId, townId, title, text, location);
-    }
-
-    public static QuestionTownLife create(TownLifeSaveRequestDto dto) {
-        return new QuestionTownLife(
-                dto.getAuthorId(),
-                dto.getTownId(),
-                dto.getTitle(), dto.getText(), dto.getLocation()
-        );
+    public QuestionTownLife(String authorId, String townId, String townAddress, String title, String text, String location) {
+        super(authorId, townId, townAddress, title, text, location);
     }
 
     @Override

--- a/src/main/java/com/gaaji/townlife/service/domain/townlife/TownLife.java
+++ b/src/main/java/com/gaaji/townlife/service/domain/townlife/TownLife.java
@@ -40,6 +40,7 @@ public abstract class TownLife extends BaseEntity {
     protected Category category;
     protected String authorId;
     protected String townId;
+    protected String townAddress;
     protected LocalDateTime deletedAt;
     @Embedded
     protected TownLifeContent content;
@@ -52,9 +53,10 @@ public abstract class TownLife extends BaseEntity {
     @OneToOne(fetch = FetchType.LAZY)
     protected TownLifeCounter townLifeCounter;
 
-    protected TownLife(String authorId, String townId, String title, String text, String location) {
+    protected TownLife(String authorId, String townId, String townAddress, String title, String text, String location) {
         this.authorId = authorId;
         this.townId = townId;
+        this.townAddress = townAddress;
         this.content = TownLifeContent.of(title, text, location);
     }
 

--- a/src/test/java/com/gaaji/townlife/config/TestBeanConfig.java
+++ b/src/test/java/com/gaaji/townlife/config/TestBeanConfig.java
@@ -1,0 +1,25 @@
+package com.gaaji.townlife.config;
+
+import com.gaaji.townlife.impl.StubAuthServiceClient;
+import com.gaaji.townlife.impl.StubTownServiceClient;
+import com.gaaji.townlife.service.adapter.gaaji.AuthServiceClient;
+import com.gaaji.townlife.service.adapter.gaaji.TownServiceClient;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+
+@TestConfiguration
+public class TestBeanConfig {
+
+    @Bean
+    public AuthServiceClient authServiceClient() {
+        System.out.println("Create Bean AuthServiceClient");
+        return new StubAuthServiceClient();
+    }
+
+    @Bean
+    public TownServiceClient townServiceClient() {
+        System.out.println("Create Bean TownServiceClient");
+        return new StubTownServiceClient();
+    }
+
+}

--- a/src/test/java/com/gaaji/townlife/impl/StubAuthServiceClient.java
+++ b/src/test/java/com/gaaji/townlife/impl/StubAuthServiceClient.java
@@ -1,0 +1,11 @@
+package com.gaaji.townlife.impl;
+
+import com.gaaji.townlife.service.adapter.gaaji.AuthServiceClient;
+import com.gaaji.townlife.service.adapter.gaaji.dto.AuthProfileDto;
+
+public class StubAuthServiceClient implements AuthServiceClient {
+    @Override
+    public AuthProfileDto getAuthProfile(String authId) {
+        return new AuthProfileDto(authId, "foo","foo", 36.5);
+    }
+}

--- a/src/test/java/com/gaaji/townlife/impl/StubTownServiceClient.java
+++ b/src/test/java/com/gaaji/townlife/impl/StubTownServiceClient.java
@@ -1,0 +1,11 @@
+package com.gaaji.townlife.impl;
+
+import com.gaaji.townlife.service.adapter.gaaji.TownServiceClient;
+import com.gaaji.townlife.service.adapter.gaaji.dto.TownAddressDto;
+
+public class StubTownServiceClient implements TownServiceClient {
+    @Override
+    public TownAddressDto getTownAddress(String townId) {
+        return new TownAddressDto("테스트동");
+    }
+}

--- a/src/test/java/com/gaaji/townlife/service/applicationservice/admin/AdminCategoryServiceTest.java
+++ b/src/test/java/com/gaaji/townlife/service/applicationservice/admin/AdminCategoryServiceTest.java
@@ -1,5 +1,6 @@
 package com.gaaji.townlife.service.applicationservice.admin;
 
+import com.gaaji.townlife.config.TestBeanConfig;
 import com.gaaji.townlife.service.controller.admin.dto.AdminCategoryListDto;
 import com.gaaji.townlife.service.controller.admin.dto.AdminCategoryModifyDto;
 import com.gaaji.townlife.service.controller.admin.dto.AdminCategorySaveRequestDto;
@@ -11,6 +12,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
@@ -20,6 +22,7 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 @SpringBootTest
+@Import(TestBeanConfig.class)
 @Transactional
 class AdminCategoryServiceTest {
     @Autowired

--- a/src/test/java/com/gaaji/townlife/service/applicationservice/category/CategoryFindServiceImplTest.java
+++ b/src/test/java/com/gaaji/townlife/service/applicationservice/category/CategoryFindServiceImplTest.java
@@ -1,5 +1,6 @@
 package com.gaaji.townlife.service.applicationservice.category;
 
+import com.gaaji.townlife.config.TestBeanConfig;
 import com.gaaji.townlife.service.controller.category.dto.CategoryListDto;
 import com.gaaji.townlife.service.domain.category.Category;
 import com.gaaji.townlife.service.domain.townlife.TownLifeType;
@@ -10,11 +11,15 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.stream.Collectors;
 
 @SpringBootTest
+@Import(TestBeanConfig.class)
+@Transactional
 @DisplayName("카테고리 조회 테스트")
 class CategoryFindServiceImplTest {
 

--- a/src/test/java/com/gaaji/townlife/service/applicationservice/category/CategorySubscriptionServiceImplTest.java
+++ b/src/test/java/com/gaaji/townlife/service/applicationservice/category/CategorySubscriptionServiceImplTest.java
@@ -1,5 +1,8 @@
 package com.gaaji.townlife.service.applicationservice.category;
 
+import com.gaaji.townlife.config.TestBeanConfig;
+import com.gaaji.townlife.service.adapter.gaaji.AuthServiceClient;
+import com.gaaji.townlife.service.adapter.gaaji.TownServiceClient;
 import com.gaaji.townlife.service.applicationservice.townlife.TownLifeFindServiceImpl;
 import com.gaaji.townlife.service.applicationservice.townlife.TownLifeSaveServiceImpl;
 import com.gaaji.townlife.service.controller.townlife.dto.TownLifeListDto;
@@ -17,17 +20,24 @@ import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.UUID;
 import java.util.stream.Collectors;
 
 @SpringBootTest
+@Import(TestBeanConfig.class)
+@Transactional
 @DisplayName("동네생활 리스트 비구독 카테고리 제외 조회 테스트")
 class CategorySubscriptionServiceImplTest {
 
     @Autowired private CategoryRepository categoryRepository;
     @Autowired private TownLifeRepository townLifeRepository;
+    @Autowired private AuthServiceClient authServiceClient;
+    @Autowired private TownServiceClient townServiceClient;
     @Autowired private TownLifeSaveServiceImpl townLifeSaveService;
     @Autowired private TownLifeFindServiceImpl townLifeFindService;
     @Autowired private CategorySubscriptionServiceImpl categorySubscriptionService;
@@ -37,11 +47,9 @@ class CategorySubscriptionServiceImplTest {
     private final String tester = "tester";
     private int testerId = 1;
 
-    private static int i = 1;
-
     void init_category() {
         categoryRepository.save(
-                Category.create("테스트_카테고리"+ i++, false, "테스트_카테고리입니다.", TownLifeType.POST));
+                Category.create(UUID.randomUUID().toString(), false, "테스트_카테고리입니다.", TownLifeType.POST));
     }
 
     void init_category_unsubscription() {

--- a/src/test/java/com/gaaji/townlife/service/applicationservice/comment/CommentServiceTest.java
+++ b/src/test/java/com/gaaji/townlife/service/applicationservice/comment/CommentServiceTest.java
@@ -1,11 +1,14 @@
 package com.gaaji.townlife.service.applicationservice.comment;
 
+import com.gaaji.townlife.config.TestBeanConfig;
 import com.gaaji.townlife.global.exceptions.api.exception.BadRequestException;
 import com.gaaji.townlife.global.exceptions.api.exception.NotYourResourceException;
 import com.gaaji.townlife.global.exceptions.api.exception.ResourceNotFoundException;
 import com.gaaji.townlife.global.exceptions.internalServer.exception.NullValueException;
 import com.gaaji.townlife.global.exceptions.internalServer.exception.TownLifeAwsS3Exception;
 import com.gaaji.townlife.service.adapter.aws.AwsS3Client;
+import com.gaaji.townlife.service.adapter.gaaji.AuthServiceClient;
+import com.gaaji.townlife.service.adapter.gaaji.TownServiceClient;
 import com.gaaji.townlife.service.applicationservice.admin.AdminCategorySaveService;
 import com.gaaji.townlife.service.applicationservice.townlife.TownLifeSaveService;
 import com.gaaji.townlife.service.controller.admin.dto.AdminCategorySaveRequestDto;
@@ -25,6 +28,7 @@ import com.gaaji.townlife.service.repository.TownLifeRepository;
 import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -35,10 +39,15 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 @SpringBootTest
+@Import(TestBeanConfig.class)
 @Transactional
 public class CommentServiceTest {
     @Autowired
     AdminCategorySaveService adminCategorySaveService;
+    @Autowired
+    AuthServiceClient authServiceClient;
+    @Autowired
+    TownServiceClient townServiceClient;
     @Autowired
     TownLifeSaveService townLifeSaveService;
     @Autowired

--- a/src/test/java/com/gaaji/townlife/service/applicationservice/townlife/TownLifeImageServiceImplTest.java
+++ b/src/test/java/com/gaaji/townlife/service/applicationservice/townlife/TownLifeImageServiceImplTest.java
@@ -1,20 +1,26 @@
 package com.gaaji.townlife.service.applicationservice.townlife;
 
+import com.gaaji.townlife.config.TestBeanConfig;
 import com.gaaji.townlife.global.exceptions.api.ApiErrorCode;
 import com.gaaji.townlife.global.exceptions.api.exception.ResourceAuthorizationException;
 import com.gaaji.townlife.global.exceptions.api.exception.ResourceRemoveException;
 import com.gaaji.townlife.global.exceptions.api.exception.ResourceSaveException;
 import com.gaaji.townlife.service.adapter.aws.AwsS3Client;
+import com.gaaji.townlife.service.adapter.gaaji.AuthServiceClient;
+import com.gaaji.townlife.service.adapter.gaaji.TownServiceClient;
 import com.gaaji.townlife.service.controller.townlife.dto.AttachedImageDto;
 import com.gaaji.townlife.service.controller.townlife.dto.TownLifeDetailDto;
 import com.gaaji.townlife.service.controller.townlife.dto.TownLifeSaveRequestDto;
 import com.gaaji.townlife.service.domain.category.Category;
 import com.gaaji.townlife.service.domain.townlife.TownLifeType;
 import com.gaaji.townlife.service.repository.CategoryRepository;
+import com.gaaji.townlife.service.repository.TownLifeCounterRepository;
 import com.gaaji.townlife.service.repository.TownLifeRepository;
+import com.gaaji.townlife.service.repository.TownLifeSubscriptionRepository;
 import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -24,6 +30,7 @@ import java.util.List;
 import java.util.UUID;
 
 @SpringBootTest
+@Import(TestBeanConfig.class)
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 @DisplayName("동네생활 게시글 이미지 서비스 테스트")
 class TownLifeImageServiceImplTest {
@@ -34,14 +41,24 @@ class TownLifeImageServiceImplTest {
     private TownLifeRepository townLifeRepository;
     @Autowired
     private TownLifeImageServiceImpl townLifeImageService;
-
     @Autowired
     private CategoryRepository categoryRepository;
+    @Autowired
+    private TownLifeCounterRepository townLifeCounterRepository;
+    @Autowired
+    private TownLifeSubscriptionRepository townLifeSubscriptionRepository;
+    @Autowired
+    private TownLifeFindEntityServiceImpl townLifeFindEntityService;
+    @Autowired
+    private TownLifeFindCountServiceImpl townLifeFindCountService;
+    @Autowired
+    private TownServiceClient townServiceClient;
+    @Autowired
+    private AuthServiceClient authServiceClient;
     @Autowired
     private TownLifeSaveServiceImpl townLifeSaveService;
     @Autowired
     private TownLifeFindServiceImpl townLifeFindService;
-
     private Category category;
 
     void init_category() {
@@ -75,7 +92,6 @@ class TownLifeImageServiceImplTest {
         MockMultipartFile multipartFile = getOneMockImage();
         List<AttachedImageDto> dto = townLifeImageService.upload(authorId, townLifeId, orderIndexes, multipartFile);
 
-        System.out.println(dto);
         Assertions.assertNotNull(dto);
         Assertions.assertEquals(1, dto.size());
     }

--- a/src/test/java/com/gaaji/townlife/service/applicationservice/townlife/TownLifeModifyServiceImplTest.java
+++ b/src/test/java/com/gaaji/townlife/service/applicationservice/townlife/TownLifeModifyServiceImplTest.java
@@ -1,5 +1,8 @@
 package com.gaaji.townlife.service.applicationservice.townlife;
 
+import com.gaaji.townlife.config.TestBeanConfig;
+import com.gaaji.townlife.service.adapter.gaaji.AuthServiceClient;
+import com.gaaji.townlife.service.adapter.gaaji.TownServiceClient;
 import com.gaaji.townlife.service.controller.townlife.dto.TownLifeDetailDto;
 import com.gaaji.townlife.service.controller.townlife.dto.TownLifeModifyRequestDto;
 import com.gaaji.townlife.service.controller.townlife.dto.TownLifeSaveRequestDto;
@@ -12,13 +15,19 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
 
 @SpringBootTest
+@Import(TestBeanConfig.class)
 @DisplayName("동네생활 수정 서비스 테스트")
 class TownLifeModifyServiceImplTest {
 
     @Autowired private CategoryRepository categoryRepository;
     @Autowired private TownLifeRepository townLifeRepository;
+    @Autowired
+    private TownServiceClient townServiceClient;
+    @Autowired
+    private AuthServiceClient authServiceClient;
     @Autowired private TownLifeSaveServiceImpl townLifeSaveService;
     @Autowired private TownLifeModifyServiceImpl townLifeModifyService;
 

--- a/src/test/java/com/gaaji/townlife/service/applicationservice/townlife/TownLifeReactionServiceImplTest.java
+++ b/src/test/java/com/gaaji/townlife/service/applicationservice/townlife/TownLifeReactionServiceImplTest.java
@@ -1,5 +1,8 @@
 package com.gaaji.townlife.service.applicationservice.townlife;
 
+import com.gaaji.townlife.config.TestBeanConfig;
+import com.gaaji.townlife.service.adapter.gaaji.AuthServiceClient;
+import com.gaaji.townlife.service.adapter.gaaji.TownServiceClient;
 import com.gaaji.townlife.service.controller.townlife.dto.ReactionDoRequestDto;
 import com.gaaji.townlife.service.controller.townlife.dto.ReactionDoResponseDto;
 import com.gaaji.townlife.service.controller.townlife.dto.TownLifeDetailDto;
@@ -11,12 +14,17 @@ import com.gaaji.townlife.service.repository.CategoryRepository;
 import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
 
 @SpringBootTest
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+@Import(TestBeanConfig.class)
 @DisplayName("동네생활 리액션 서비스 테스트")
 class TownLifeReactionServiceImplTest {
-
+    @Autowired
+    private TownServiceClient townServiceClient;
+    @Autowired
+    private AuthServiceClient authServiceClient;
     @Autowired
     private CategoryRepository categoryRepository;
     @Autowired

--- a/src/test/java/com/gaaji/townlife/service/applicationservice/townlife/TownLifeRemoveServiceImplTest.java
+++ b/src/test/java/com/gaaji/townlife/service/applicationservice/townlife/TownLifeRemoveServiceImplTest.java
@@ -1,7 +1,10 @@
 package com.gaaji.townlife.service.applicationservice.townlife;
 
+import com.gaaji.townlife.config.TestBeanConfig;
 import com.gaaji.townlife.global.exceptions.api.exception.ResourceAuthorizationException;
 import com.gaaji.townlife.global.exceptions.api.exception.ResourceNotFoundException;
+import com.gaaji.townlife.service.adapter.gaaji.AuthServiceClient;
+import com.gaaji.townlife.service.adapter.gaaji.TownServiceClient;
 import com.gaaji.townlife.service.controller.townlife.dto.TownLifeSaveRequestDto;
 import com.gaaji.townlife.service.domain.category.Category;
 import com.gaaji.townlife.service.domain.townlife.TownLifeType;
@@ -13,11 +16,16 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
 
 @SpringBootTest
+@Import(TestBeanConfig.class)
 @DisplayName("동네생활 삭제 서비스 테스트")
 class TownLifeRemoveServiceImplTest {
-
+    @Autowired
+    private TownServiceClient townServiceClient;
+    @Autowired
+    private AuthServiceClient authServiceClient;
     @Autowired
     private CategoryRepository categoryRepository;
     @Autowired

--- a/src/test/java/com/gaaji/townlife/service/applicationservice/townlife/TownLifeSaveServiceImplTest.java
+++ b/src/test/java/com/gaaji/townlife/service/applicationservice/townlife/TownLifeSaveServiceImplTest.java
@@ -1,10 +1,14 @@
 package com.gaaji.townlife.service.applicationservice.townlife;
 
+import com.gaaji.townlife.config.TestBeanConfig;
+import com.gaaji.townlife.service.adapter.gaaji.AuthServiceClient;
+import com.gaaji.townlife.service.adapter.gaaji.TownServiceClient;
 import com.gaaji.townlife.service.controller.townlife.dto.TownLifeDetailDto;
 import com.gaaji.townlife.service.controller.townlife.dto.TownLifeSaveRequestDto;
 import com.gaaji.townlife.service.domain.category.Category;
 import com.gaaji.townlife.service.domain.townlife.TownLifeType;
 import com.gaaji.townlife.service.repository.CategoryRepository;
+import com.gaaji.townlife.service.repository.TownLifeCounterRepository;
 import com.gaaji.townlife.service.repository.TownLifeRepository;
 import com.gaaji.townlife.service.repository.TownLifeSubscriptionRepository;
 import org.junit.jupiter.api.Assertions;
@@ -12,18 +16,40 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.transaction.annotation.Transactional;
 
 @SpringBootTest
+@Import(TestBeanConfig.class)
 @DisplayName("동네생활 저장 서비스 테스트")
 class TownLifeSaveServiceImplTest {
 
     @Autowired private TownLifeRepository townLifeRepository;
     @Autowired private TownLifeSubscriptionRepository townLifeSubscriptionRepository;
+    @Autowired private TownLifeCounterRepository townLifeCounterRepository;
     @Autowired private CategoryRepository categoryRepository;
-    @Autowired private TownLifeSaveServiceImpl townLifeSaveService;
+    @Autowired
+    private AuthServiceClient authServiceClient;
+    @Autowired
+    private TownServiceClient townServiceClient;
+    @Autowired
+    private TownLifeSaveServiceImpl townLifeSaveService;
+
+//    @BeforeEach
+//    void init() {
+//        townLifeSaveService = new TownLifeSaveServiceImpl(
+//                categoryRepository,
+//                townLifeRepository,
+//                townLifeCounterRepository,
+//                townLifeSubscriptionRepository,
+//                new StubAuthServiceClient(),
+//                new StubTownServiceClient()
+//        );
+//    }
 
     @Test
     @DisplayName("POST 동네생활 저장")
+    @Transactional
     void create_new_post_town_life() {
         Category category = categoryRepository.save(
                 Category.create("테스트_카테고리_POST_저장", true, "테스트_카테고리입니다.", TownLifeType.POST));
@@ -39,6 +65,8 @@ class TownLifeSaveServiceImplTest {
         Assertions.assertNotNull(saveDto.getCategory());
         Assertions.assertEquals(saveDto.getCreatedAt(), saveDto.getUpdatedAt());
         Assertions.assertEquals(dto.getAuthorId(), saveDto.getAuthorId());
+        Assertions.assertEquals("foo", saveDto.getAuthorNickName());
+        Assertions.assertEquals("테스트동", saveDto.getTownAddress());
         Assertions.assertEquals(dto.getTitle(), saveDto.getTitle());
         Assertions.assertEquals(dto.getText(), saveDto.getText());
         Assertions.assertEquals(dto.getLocation(), saveDto.getLocation());
@@ -46,6 +74,7 @@ class TownLifeSaveServiceImplTest {
 
     @Test
     @DisplayName("QUESTION 동네생활 저장")
+    @Transactional
     void create_new_question_town_life() {
         Category category = categoryRepository.save(
                 Category.create("테스트_카테고리_QUES_저장", true, "테스트_카테고리입니다.", TownLifeType.QUESTION));
@@ -61,6 +90,8 @@ class TownLifeSaveServiceImplTest {
         Assertions.assertNotNull(saveDto.getCategory());
         Assertions.assertEquals(saveDto.getCreatedAt(), saveDto.getUpdatedAt());
         Assertions.assertEquals(dto.getAuthorId(), saveDto.getAuthorId());
+        Assertions.assertEquals("foo", saveDto.getAuthorNickName());
+        Assertions.assertEquals("테스트동", saveDto.getTownAddress());
         Assertions.assertEquals(dto.getTitle(), saveDto.getTitle());
         Assertions.assertEquals(dto.getText(), saveDto.getText());
         Assertions.assertEquals(dto.getLocation(), saveDto.getLocation());

--- a/src/test/java/com/gaaji/townlife/service/applicationservice/townlife/TownLifeSubscriptionServiceImplTest.java
+++ b/src/test/java/com/gaaji/townlife/service/applicationservice/townlife/TownLifeSubscriptionServiceImplTest.java
@@ -1,7 +1,10 @@
 package com.gaaji.townlife.service.applicationservice.townlife;
 
+import com.gaaji.townlife.config.TestBeanConfig;
 import com.gaaji.townlife.global.exceptions.api.exception.ResourceAlreadyExistException;
 import com.gaaji.townlife.global.exceptions.api.exception.ResourceRemoveException;
+import com.gaaji.townlife.service.adapter.gaaji.AuthServiceClient;
+import com.gaaji.townlife.service.adapter.gaaji.TownServiceClient;
 import com.gaaji.townlife.service.controller.townlife.dto.TownLifeSaveRequestDto;
 import com.gaaji.townlife.service.domain.category.Category;
 import com.gaaji.townlife.service.domain.townlife.TownLifeType;
@@ -10,12 +13,17 @@ import com.gaaji.townlife.service.repository.TownLifeRepository;
 import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
 
 @SpringBootTest
+@Import(TestBeanConfig.class)
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 @DisplayName("동네생활 게시글 알림구독 서비스 테스트")
 class TownLifeSubscriptionServiceImplTest {
-
+    @Autowired
+    private TownServiceClient townServiceClient;
+    @Autowired
+    private AuthServiceClient authServiceClient;
     @Autowired
     private CategoryRepository categoryRepository;
     @Autowired


### PR DESCRIPTION
# [GM-301] townlife connect auth service
## Description
> townlife server와 auth server, town server 간의 feign client를 추가/적용한 PR이다.

## PR Type
- [ ] Hotfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor (code, package, etc.)
- [ ] Build (gradle, spring, etc) 
- [ ] Documentation content changes (api docs, etc.)
- [ ] Infra (cloud, security, etc.)
- [ ] Other... Please describe :

## Issues
### AuthServiceClient
```java
@FeignClient(value = "auth-service", primary = false)
public interface AuthServiceClient {

    @GetMapping("/auth/{authId}")
    AuthProfileDto getAuthProfile(@PathVariable String authId);

}
```

### TownServiceClient
```java
@FeignClient(value = "town-service", primary = false)
public interface TownServiceClient {

    @GetMapping("/town/{townId}")
    TownAddressDto getTownAddress(@PathVariable("townId") String townId);

}
```

## Think About..  
> 

## Conclusion  
> 
